### PR TITLE
[PC-634] Chore: PrivacyManifest 파일 생성

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
@@ -46,7 +46,95 @@ extension Project {
         ]
       ),
       sources: ["Sources/**"],
-      resources: ["Resources/**"],
+      resources: .resources(
+        ["Resources/**"],
+        privacyManifest: .privacyManifest(
+          tracking: false,
+          trackingDomains: [],
+          collectedDataTypes: [
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeName",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeEmailAddress",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypePhoneNumber",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeCoarseLocation",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeSensitiveInfo",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeContacts",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeUserID",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeDeviceID",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ],
+            [
+              "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeOtherDataTypes",
+              "NSPrivacyCollectedDataTypeLinked": true,
+              "NSPrivacyCollectedDataTypeTracking": false,
+              "NSPrivacyCollectedDataTypePurposes": [
+                "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+              ]
+            ]
+          ],
+          accessedApiTypes: [
+            [
+              "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+              "NSPrivacyAccessedAPITypeReasons": [
+                "CA92.1",
+              ],
+            ],
+          ]
+        )
+      ),
       entitlements: .file(path: .relativeToRoot("Piece-iOS.entitlements")),
       dependencies: dependencies,
       settings: .settings(


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-634](https://yapp25app3.atlassian.net/browse/PC-634)

## 👷🏼‍♂️ 변경 사항
- 앱에서 사용하는 개인정보를 다루는 파일인 Privacy Manifest 관련 내용을 담은 `PrivacyInfo.xcprivacy` 파일을 생성하는 Tuist 설정 추가
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-634]: https://yapp25app3.atlassian.net/browse/PC-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ