### PR TITLE
[PC-638] Feat: 앱 테마를 라이트모드로 고정

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
@@ -22,6 +22,7 @@ extension Project {
       deploymentTargets: AppConstants.deploymentTargets,
       infoPlist: .extendingDefault(
         with: [
+          "UIUserInterfaceStyle": "Light",
           "UILaunchStoryboardName": "LaunchScreen",
           "NSCameraUsageDescription": "프로필 생성 시 사진 첨부를 위해 카메라 접근 권한이 필요합니다.",
           "NSPhotoLibraryUsageDescription": "프로필 생성 시 사진 첨부를 위해 앨범 접근 권한이 필요합니다.",


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-638](https://yapp25app3.atlassian.net/browse/PC-638)

## 👷🏼‍♂️ 변경 사항
- 사용자가 기기를 다크모드로 설정 시 배경을 일일이 흰색 지정해주지 않으면 검정 배경이 되어버림
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-638]: https://yapp25app3.atlassian.net/browse/PC-638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ