### PR TITLE
[PC-640] Fix: 전화번호 인증 화면에서 앱이 죽는 현상 수정

### DIFF
--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
@@ -61,6 +61,7 @@ struct VerifingContactView: View {
           RoundedButton(
             type: viewModel.phoneNumberTextfieldButtonType,
             buttonText: viewModel.recivedCertificationNumberButtonText,
+            width: .maxWidth,
             action: {
               viewModel.handleAction(.reciveCertificationNumber)
             }
@@ -71,7 +72,6 @@ struct VerifingContactView: View {
           viewModel.phoneNumber = newValue.filter { $0.isNumber }
         }
         .textContentType(.telephoneNumber)
-        
         
         if viewModel.showVerificationField {
           PCTextField(
@@ -86,6 +86,7 @@ struct VerifingContactView: View {
             RoundedButton(
               type: viewModel.verificationCodeTextfieldButtonType,
               buttonText: "확인",
+              width: .maxWidth,
               action: {
                 viewModel.handleAction(.checkCertificationNumber)
               }
@@ -105,8 +106,8 @@ struct VerifingContactView: View {
         )
       }
       .padding(.bottom, 10)
-      .padding(.horizontal, 20)
     }
+    .padding(.horizontal, 20)
     .onChange(of: viewModel.tapNextButtonFlag) { _, newValue in
       router.setRoute(.termsAgreement)
     }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-640](https://yapp25app3.atlassian.net/browse/PC-640)

## 👷🏼‍♂️ 변경 사항
- 하나의 `FocusState`에 두 개의 `TextField`가 바인딩 되어 있어 생긴 오류
  - `FocusState`를 두 개로 분리하여 해결
- UI 오류 수정
  - horizontal padding 화면 전체 VStack에 적용
  - 버튼 컴포넌트 리팩토링 하면서 width를 .maxWidth로 변경
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-640]: https://yapp25app3.atlassian.net/browse/PC-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ