### PR TITLE
[PC-661] Fix: 서버에서 응답받은 프로필 정보를 메인 스레드에서 업데이트 하도록 수정

### DIFF
--- a/Presentation/Feature/Profile/Sources/ProfileViewModel.swift
+++ b/Presentation/Feature/Profile/Sources/ProfileViewModel.swift
@@ -10,6 +10,7 @@ import PCFoundationExtension
 import UseCases
 
 @Observable
+@MainActor
 final class ProfileViewModel {
   enum Action { }
   
@@ -29,7 +30,7 @@ final class ProfileViewModel {
   private func fetchUserProfile() async {
     do {
       let entity = try await getProfileUseCase.execute()
-      userProfile = UserProfile(
+      let userProfile = UserProfile(
         nickname: entity.nickname,
         description: entity.description,
         age: entity.age,
@@ -41,10 +42,15 @@ final class ProfileViewModel {
         smokingStatus: entity.smokingStatus,
         imageUri: entity.imageUri
       )
+      updateUserProfile(userProfile)
       error = nil
     } catch {
       self.error = error
     }
     isLoading = false
+  }
+  
+  private func updateUserProfile(_ profile: UserProfile) {
+    userProfile = profile
   }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-661](https://yapp25app3.atlassian.net/browse/PC-661)

## 👷🏼‍♂️ 변경 사항
- 프로필 탭 진입 시 사용자 프로필 영역이 안 보이는 이슈가 있었음
- ViewModel의 `userProfile` 값 업데이트를 메인 스레드에서 하지 않고 있기 때문으로 추측하여 수정해봄
 
## 💬 참고 사항
- 유사한 케이스가 있을 때 스레드를 먼저 의심해보세요

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-661]: https://yapp25app3.atlassian.net/browse/PC-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ