### PR TITLE
[PC-616] Build: Debug 환경과 Release 환경 XCConfig 설정파일 분리

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
@@ -143,8 +143,8 @@ extension Project {
           "OTHER_LDFLAGS": ["-ObjC"]
         ],
         configurations: [
-          .debug(name: "Debug", xcconfig: .relativeToRoot("Config.xcconfig")),
-          .release(name: "Release", xcconfig: .relativeToRoot("Config.xcconfig"))
+          .debug(name: "Debug", xcconfig: .relativeToRoot("Debug.xcconfig")),
+          .release(name: "Release", xcconfig: .relativeToRoot("Release.xcconfig"))
         ]
       )
       //          .settings(


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-616](https://yapp25app3.atlassian.net/browse/PC-616)

## 👷🏼‍♂️ 변경 사항
- Debug/Release 환경 간 `baseUrl` 값을 다르게 설정하기 위해
 
## 💬 참고 사항
- xcconfig 파일 디스코드에 공유

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-616]: https://yapp25app3.atlassian.net/browse/PC-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ