### PR TITLE
[PC-742] Fix: 탈퇴하기 화면에 재진입 불가능한 오류 수정

### DIFF
--- a/Presentation/Feature/Settings/Sources/SettingsView.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsView.swift
@@ -86,6 +86,7 @@ struct SettingsView: View {
     .onChange(of: viewModel.destination) { _, destination in
       guard let destination else { return }
       router.push(to: destination)
+      viewModel.handleAction(.clearDestination)
     }
   }
   

--- a/Presentation/Feature/Settings/Sources/SettingsViewModel.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsViewModel.swift
@@ -25,6 +25,7 @@ final class SettingsViewModel {
     case logoutItemTapped
     case confirmLogoutButton
     case withdrawButtonTapped
+    case clearDestination
   }
   
   var sections = [SettingSection]()
@@ -110,6 +111,9 @@ final class SettingsViewModel {
       break
     case .withdrawButtonTapped:
       destination = .withdraw
+      
+    case .clearDestination:
+      destination = nil
     }
   }
   


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-742](https://yapp25app3.atlassian.net/browse/PC-742)

## 👷🏼‍♂️ 변경 사항
- 다른 화면으로 진입할 때 `destination`에 `nil`을 할당하여 같은 화면으로 재진입이 가능하도록 수정함
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-742]: https://yapp25app3.atlassian.net/browse/PC-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ