### PR TITLE
[PC-769] Fix: 탈퇴하기 완료 후 화면이 이동하지 않는 문제 수정

### DIFF
--- a/Data/PCNetwork/Sources/APIResponseModel.swift
+++ b/Data/PCNetwork/Sources/APIResponseModel.swift
@@ -6,7 +6,7 @@
 //
 
 struct APIResponse<T: Decodable>: Decodable {
-    let status: String
-    let message: String
+    let status: String?
+    let message: String?
     let data: T
 }

--- a/Presentation/Feature/Splash/Sources/SplashViewModel.swift
+++ b/Presentation/Feature/Splash/Sources/SplashViewModel.swift
@@ -79,7 +79,8 @@ final class SplashViewModel {
           print("forbidden")
           destination = .login
         case .notFound:
-          print("not fount")
+          print("not found")
+          destination = .login
         case .internalServerError:
           print("internal server error")
         case .statusCode(let int):

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
@@ -12,6 +12,7 @@ import LocalStorage
 import KakaoSDKUser
 import AuthenticationServices
 
+@MainActor
 @Observable
 final class WithdrawConfirmViewModel: NSObject {
   enum Action {


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-769](https://yapp25app3.atlassian.net/browse/PC-769)

## 👷🏼‍♂️ 변경 사항
-`APIResponse`의 `message`가 `null`로 날아와 디코딩 오류가 발생하고 있었음
- `message`를 optional로 변경
 
## 💬 참고 사항
- 이제 탈퇴하기 후 정상적으로 스플래시 화면으로 이동합니다!

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-769]: https://yapp25app3.atlassian.net/browse/PC-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ