### PR TITLE
[PC-775] Fix: 프로필 미리보기 화면에서 X 눌렀을 때 반응이 없는 현상 수정

### DIFF
--- a/Presentation/Feature/SignUp/Sources/CompleteCreateProfile/CompleteCreateProfileView.swift
+++ b/Presentation/Feature/SignUp/Sources/CompleteCreateProfile/CompleteCreateProfileView.swift
@@ -67,7 +67,7 @@ struct CompleteCreateProfileView: View {
         buttonText: "내 프로필 확인하기",
         width: .maxWidth
       ) {
-        router.setRoute(.previewProfileBasic)
+        router.setRouteAndPush(root: .home, pushTo: .previewProfileBasic)
       }
     }
     .padding(.top, 12)


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-775](https://yapp25app3.atlassian.net/browse/PC-775)

## 👷🏼‍♂️ 변경 사항
- 원래는 X를 누르면 홈 화면으로 가야 함
- 원인: 회원가입 완료 화면에서 프로필 미리보기 화면으로 이동할 때 `.setRoute`를 통해 이동하면, 루트 화면이 프로필 미리보기 화면이기 때문에`pop` 해도 프로필 미리보기 화면
- 해결: `.setRouteAndPush`를 이용해 루트를 홈 화면으로 설정한 후 이동하도록 수정
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-775]: https://yapp25app3.atlassian.net/browse/PC-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ