### PR TITLE
[PC-660] Fix: 카카오로그인하기 버튼 탭 시 메인스레드에서 동작하지 않는 문제 수정

### DIFF
--- a/Presentation/Feature/Login/Sources/Login/LoginViewModel.swift
+++ b/Presentation/Feature/Login/Sources/Login/LoginViewModel.swift
@@ -15,6 +15,7 @@ import AuthenticationServices
 import UseCases
 import LocalStorage
 
+@MainActor
 @Observable
 final class LoginViewModel: NSObject {
   
@@ -31,6 +32,7 @@ final class LoginViewModel: NSObject {
   private let socialLoginUseCase: SocialLoginUseCase
   private(set) var isSuccessfulSignUp: Bool = false
   private(set) var isSuccessfulLogin: Bool = false
+  
   func handleAction(_ action: Action) {
     switch action {
     case .tapAppleLoginButton:


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-660](https://yapp25app3.atlassian.net/browse/PC-660)

## 👷🏼‍♂️ 변경 사항
- `LoginViewModel`에 `@MainActor` 추가
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-660]: https://yapp25app3.atlassian.net/browse/PC-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ