### PR TITLE
[PC-904] 매칭 메인 화면에서 디자인가이드와 다른 UI 수정

### DIFF
--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
@@ -211,6 +211,8 @@ struct MatchingMainView: View {
   }
   
   private var profileInfo: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: 4) {
         Text(matchingMainViewModel.description)
           .multilineTextAlignment(.leading)
         Text("\(matchingMainViewModel.name)입니다")


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-904](https://yapp25app3.atlassian.net/browse/PC-904)

## 👷🏼‍♂️ 변경 사항
- 가로 divider 위치 수정
- `나를 표현하는 한 마디`가 2줄일 경우 정렬을 `.leading`으로 수정
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-904]: https://yapp25app3.atlassian.net/browse/PC-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ