### PR TITLE
[PC-896] 연락처 차단 시 인코딩 전 전화번호 형식을 01012345678로 통일

### DIFF
--- a/Domain/UseCases/Sources/SignUp/BlockContactsUseCase.swift
+++ b/Domain/UseCases/Sources/SignUp/BlockContactsUseCase.swift
@@ -24,8 +24,22 @@ final class BlockContactsUseCaseImpl: BlockContactsUseCase {
   }
   
   func execute(phoneNumbers: [String]) async throws -> VoidModel {
-    let encodedContacts = phoneNumbers.compactMap { $0.data(using: .utf8)?.base64EncodedString() }
+    let encodedContacts = phoneNumbers
+      .compactMap { standardizePhoneNumber($0) }
+      .compactMap { $0.data(using: .utf8)?.base64EncodedString() }
     let blockContactsModel = BlockContactsModel(phoneNumbers: encodedContacts)
     return try await repository.postBlockContacts(phoneNumbers: blockContactsModel)
+  }
+  
+  private func standardizePhoneNumber(_ phoneNumber: String) -> String {
+      // Remove all non-numeric characters
+      let numericOnly = phoneNumber.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+      
+      // If the number starts with +82, replace it with 0
+      if numericOnly.hasPrefix("82") {
+          return "0" + numericOnly.dropFirst(2)
+      } else {
+          return numericOnly
+      }
   }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-896](https://yapp25app3.atlassian.net/browse/PC-896)

## 👷🏼‍♂️ 변경 사항
- `+821012345678`, `010-1234-5678` 등 다양한 형식의 연락처로 추출되어 서버에서 제대로 연락처 차단이 되지 않는 문제가 있었음
- 전화번호를 base64 인코딩 하기 전에 형식을 `01012345678` 형식으로 변환하도록 함
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-896]: https://yapp25app3.atlassian.net/browse/PC-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ