### PR TITLE
[PC-912] Fix: 프로필(생성/수정) 화면의 연락처 타입에 따라 서로 다른 연락처 필드를 구성하도록 변경

### DIFF
--- a/Presentation/DesignSystem/Sources/PCContactField.swift
+++ b/Presentation/DesignSystem/Sources/PCContactField.swift
@@ -1,0 +1,130 @@
+//
+//  PCContactField.swift
+//  DesignSystem
+//
+//  Created by 홍승완 on 5/16/25.
+//
+
+import SwiftUI
+
+// MARK: UI Model
+public struct ContactDisplayModel: Identifiable, Hashable {
+  public enum ContactType: String {
+    case kakao = "KAKAO_TALK_ID"
+    case openKakao = "OPEN_CHAT_URL"
+    case instagram = "INSTAGRAM_ID"
+    case phone = "PHONE_NUMBER"
+    case unknown = "UNKNOWN"
+    
+    public var icon: Image {
+      switch self {
+      case .kakao:
+        return DesignSystemAsset.Icons.kakao32.swiftUIImage
+      case .openKakao:
+        return DesignSystemAsset.Icons.kakaoOpenchat32.swiftUIImage
+      case .instagram:
+        return DesignSystemAsset.Icons.instagram32.swiftUIImage
+      case .phone:
+        return DesignSystemAsset.Icons.cellFill32.swiftUIImage
+      case .unknown:
+        return Image(systemName: "questionmark")
+      }
+    }
+  }
+  
+  public let id: UUID
+  public var type: ContactType
+  public var value: String
+  public var image: Image { type.icon }
+  
+  public init(id: UUID, type: ContactType, value: String) {
+    self.id = id
+    self.type = type
+    self.value = value
+  }
+}
+
+public struct PCContactField: View {
+  // MARK: - Injected Properties
+  @Binding private var contact: ContactDisplayModel
+  private let action: () -> Void
+  
+  // MARK: - Internal State
+  @State private var contactFieldHeight: CGFloat = 24.0
+  
+  // MARK: - Computed Properties
+  private var estimatedLineCount: Int {
+    max(1, Int(contactFieldHeight / PCContactFieldConstant.lineHeight))
+  }
+  
+  // MARK: - Initializer
+  public init(
+    contact: Binding<ContactDisplayModel>,
+    action: @escaping () -> Void
+  ) {
+    self._contact = contact
+    self.action = action
+  }
+  
+  // MARK: Body
+  public var body: some View {
+    HStack(spacing: 16) {
+      contactTypeButtonView
+      contactField
+    }
+    .padding(.horizontal, PCContactFieldConstant.horizontalPadding)
+    .padding(.vertical, PCContactFieldConstant.verticalPadding)
+    .background(Color.grayscaleLight3)
+    .cornerRadius(8)
+  }
+  
+  private var contactTypeButtonView: some View {
+    VStack {
+      Button(action: action) {
+        HStack {
+          contact.image
+          DesignSystemAsset.Icons.chevronDown24.swiftUIImage
+        }
+      }
+
+      if contact.type == .openKakao, estimatedLineCount >= 2 {
+        Spacer()
+      }
+    }
+  }
+  
+  @ViewBuilder
+  private var contactField: some View {
+    switch contact.type {
+    case .openKakao:
+      TextEditor(text: $contact.value)
+        .font(DesignSystemFontFamily.Pretendard.medium.swiftUIFont(size: 16))
+        .foregroundStyle(Color.grayscaleBlack)
+        .scrollContentBackground(.hidden)
+        .background(Color.grayscaleLight3)
+        .background(
+          GeometryReader { geo in
+            Color.clear
+              .onChange(of: geo.size.height) { _, newValue in
+                contactFieldHeight = newValue
+              }
+          }
+        )
+    default:
+      TextField("", text: $contact.value)
+        .pretendard(.body_M_M)
+        .foregroundStyle(Color.grayscaleBlack)
+        .background(Color.grayscaleLight3)
+        .frame(height: 24)
+    }
+  }
+}
+
+// MARK: Extenstion
+extension PCContactField {
+  private enum PCContactFieldConstant {
+    static let horizontalPadding: CGFloat = 16
+    static let verticalPadding: CGFloat = 14
+    static let lineHeight: CGFloat = 24.0
+  }
+}

--- a/Presentation/DesignSystem/Sources/PCContactField.swift
+++ b/Presentation/DesignSystem/Sources/PCContactField.swift
@@ -54,7 +54,7 @@ public struct PCContactField: View {
   
   // MARK: - Computed Properties
   private var estimatedLineCount: Int {
-    max(1, Int(contactFieldHeight / PCContactFieldConstant.lineHeight))
+    max(1, Int(contactFieldHeight / Constant.lineHeight))
   }
   
   // MARK: - Initializer
@@ -72,8 +72,8 @@ public struct PCContactField: View {
       contactTypeButtonView
       contactField
     }
-    .padding(.horizontal, PCContactFieldConstant.horizontalPadding)
-    .padding(.vertical, PCContactFieldConstant.verticalPadding)
+    .padding(.horizontal, Constant.horizontalPadding)
+    .padding(.vertical, Constant.verticalPadding)
     .background(Color.grayscaleLight3)
     .cornerRadius(8)
   }
@@ -122,7 +122,7 @@ public struct PCContactField: View {
 
 // MARK: Extenstion
 extension PCContactField {
-  private enum PCContactFieldConstant {
+  private enum Constant {
     static let horizontalPadding: CGFloat = 16
     static let verticalPadding: CGFloat = 14
     static let lineHeight: CGFloat = 24.0

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -35,14 +35,7 @@ struct EditProfileView: View {
   
   var body: some View {
     ZStack {
-      Color.clear // 배경 영역 - 탭 시 포커스 해제
-        .ignoresSafeArea()
-        .onTapGesture {
-          focusField = nil
-        }
-      
       VStack {
-        
         navigationBar
         
         ScrollViewReader { proxy in
@@ -95,9 +88,16 @@ struct EditProfileView: View {
               }
     
             }
-            .padding(.bottom, 200)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 260)
+            .background(
+              Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture {
+                  focusField = nil
+                }
+            )
           }
-          .padding(.horizontal, 20)
           .scrollIndicators(.hidden)
           .onChange(of: focusField) { _, newValue in
             withAnimation {
@@ -543,6 +543,8 @@ struct EditProfileView: View {
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }
+    .onAppear {
+      focusField = nil
     }
   }
   

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -58,7 +58,7 @@ struct EditProfileView: View {
               descriptionTextField.id("description_scroll")
               
               // 생년월일
-              birthdateTextField.id("birthdate_scroll")
+              birthdateTextField.id("birthDate_scroll")
               
               // 활동지역
               locationTextField.id("location_scroll")

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -412,38 +412,8 @@ struct EditProfileView: View {
       Text("연락처")
         .pretendard(.body_S_M)
         .foregroundStyle(Color.grayscaleDark3)
-      ForEach(viewModel.contacts, id: \.id) { contact in
-        PCTextEditor(
-          text: Binding(
-            get: { contact.value },
-            set: { newValue in
-              if viewModel.isAllowedInput(newValue),
-                 let index = viewModel.contacts.firstIndex(where: { $0.id == contact.id }) {
-                viewModel.contacts[index].value = newValue
-                viewModel.isEditing = true
-              }
-            }
-          ),
-          focusState: $focusField,
-          focusField: "contact_\(contact.id)",
-          image: iconFor(contactType: contact.type),
-          showDeleteButton: viewModel.contacts.first != contact,
-          tapDeleteButton: {
-            if let index = viewModel.contacts.firstIndex(where: { $0.id == contact.id }) {
-              viewModel.removeContact(at: index)
-            }
-          },
-          action: {
-            focusField = nil
-            viewModel.selectedContactForIconChange = contact
-            viewModel.isContactTypeChangeSheetPresented = true
-          }
-        )
-        .textInputAutocapitalization(.never)
-        .autocorrectionDisabled(true)
-        .frame(minHeight: 72)
-        .id("contact_\(contact.id)_scroll")
-      }
+      
+      EditContactContainer(viewModel: viewModel, focusField: $focusField)
     }
   }
   
@@ -573,20 +543,6 @@ struct EditProfileView: View {
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }
-  }
-  
-  private func iconFor(contactType: ContactModel.ContactType) -> Image {
-    switch contactType {
-    case .kakao:
-      return DesignSystemAsset.Icons.kakao32.swiftUIImage
-    case .openKakao:
-      return DesignSystemAsset.Icons.kakaoOpenchat32.swiftUIImage
-    case .instagram:
-      return DesignSystemAsset.Icons.instagram32.swiftUIImage
-    case .phone:
-      return DesignSystemAsset.Icons.cellFill32.swiftUIImage
-    default:
-      return Image(systemName: "questionmark")
     }
   }
   
@@ -632,6 +588,118 @@ struct EditProfileView: View {
       Rectangle()
         .foregroundStyle(Color.grayscaleDark2)
         .cornerRadius(12)
+    )
+  }
+}
+
+fileprivate struct EditContactContainer: View {
+  @Bindable var viewModel: EditProfileViewModel
+  private var focusField: FocusState<String?>.Binding
+  
+  fileprivate init(
+    viewModel: EditProfileViewModel,
+    focusField: FocusState<String?>.Binding
+  ) {
+    self._viewModel = Bindable(wrappedValue: viewModel)
+    self.focusField = focusField
+  }
+  
+  fileprivate var body: some View {
+    ScrollViewReader { proxy in
+      VStack {
+        contactFields
+      }
+      .onChange(of: focusField.wrappedValue) { _, newValue in
+        withAnimation {
+          if let field = newValue {
+            proxy.scrollTo("\(field)_scroll", anchor: .center)
+          }
+        }
+      }
+      .onChange(of: viewModel.contacts) { oldValue, newValue in
+        handleContactsChange(oldValue: oldValue, newValue: newValue)
+      }
+    }
+  }
+  
+  private var contactFields: some View {
+    ForEach(viewModel.contacts, id: \.id) { contact in
+      HStack(spacing: 16) {
+        PCContactField(
+          contact: bindingForContact(id: contact.id),
+          action: {
+            viewModel.selectedContactForIconChange = contact
+            viewModel.isContactTypeChangeSheetPresented = true
+          }
+        )
+        .focused(focusField, equals: "contact_\(contact.id)")
+        .id("contact_\(contact.id)_scroll")
+        
+        if viewModel.canDeleteContactField(contact: contact) {
+          DeleteButton {
+            viewModel.removeContact(for: contact)
+          }
+        }
+      }
+    }
+  }
+  
+  private func bindingForContact(id: UUID) -> Binding<ContactDisplayModel> {
+    Binding<ContactDisplayModel>(
+      get: {
+        guard let contact = viewModel.contacts.first(where: { $0.id == id }) else {
+          return ContactDisplayModel(id: id, type: .unknown, value: "")
+        }
+        return ContactDisplayModel(
+          id: contact.id,
+          type: ContactDisplayModel.ContactType(rawValue: contact.type.rawValue) ?? .unknown,
+          value: contact.value
+        )
+      },
+      set: { newContact in
+        guard let index = viewModel.contacts.firstIndex(where: { $0.id == id }) else { return }
+        if viewModel.isAllowedInput(newContact.value) {
+          viewModel.contacts[index].value = newContact.value
+          viewModel.contacts[index].type = ContactModel.ContactType(rawValue: newContact.type.rawValue) ?? .unknown
+          viewModel.isEditing = true
+        }
+      }
+    )
+  }
+  
+  private func handleContactsChange(oldValue: [ContactModel], newValue: [ContactModel]) {
+    let oldIds = Set(oldValue.map { $0.id })
+    let newIds = Set(newValue.map { $0.id })
+
+    if let addedId = newIds.subtracting(oldIds).first {
+      self.focusField.wrappedValue = "contact_\(addedId)"
+      return
+    }
+
+    for (old, new) in zip(oldValue, newValue) {
+      if old.id == new.id && old != new {
+        self.focusField.wrappedValue = "contact_\(new.id)"
+        return
+      }
+    }
+  }
+}
+
+fileprivate struct DeleteButton: View {
+  private let action: (() -> Void)?
+  
+  fileprivate init(action: (() -> Void)?) {
+    self.action = action
+  }
+  
+  fileprivate var body: some View {
+    Button(
+      action: { action?() },
+      label: {
+        DesignSystemAsset.Icons.deletCircle20.swiftUIImage
+          .renderingMode(.template)
+          .foregroundStyle(Color.grayscaleLight1)
+      }
     )
   }
 }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -428,3 +428,20 @@ final class EditProfileViewModel {
       }
   }
 }
+
+// MARK: ContactContainer
+extension EditProfileViewModel {
+  func canDeleteContactField(contact: ContactModel) -> Bool {
+    guard let index = contacts.firstIndex(where: { $0.id == contact.id }) else {
+      return false
+    }
+    return index > 0
+  }
+  
+  func removeContact(for contact: ContactModel) {
+    if let index = contacts.firstIndex(where: { $0.id == contact.id }),
+       index > 0 {
+      removeContact(at: index)
+    }
+  }
+}

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -335,7 +335,7 @@ final class EditProfileViewModel {
   
   func updateContactType(for contact: ContactModel, newType: ContactModel.ContactType) {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }) {
-      contacts[index].type = newType
+      contacts[index] = ContactModel(type: newType, value: contact.value)
       isEditing = true
     }
   }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -79,7 +79,7 @@ struct CreateBasicInfoView: View {
               descriptionTextField.id("description_scroll")
               
               // 생년월일
-              birthdateTextField.id("birthdate_scroll")
+              birthdateTextField.id("birthDate_scroll")
               
               // 활동지역
               locationTextField.id("location_scroll")

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -534,6 +534,8 @@ struct CreateBasicInfoView: View {
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }
+    .onAppear {
+      focusField = nil
     }
   }
 

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -369,3 +369,21 @@ final class CreateBasicInfoViewModel {
     self.isValidProfileImage = true
   }
 }
+
+// MARK: ContactContainer
+extension CreateBasicInfoViewModel {
+  func canDeleteContactField(contact: ContactModel) -> Bool {
+    guard let index = contacts.firstIndex(where: { $0.id == contact.id }) else {
+      return false
+    }
+    return index > 0
+  }
+  
+  func removeContact(for contact: ContactModel) {
+    if let index = contacts.firstIndex(where: { $0.id == contact.id }),
+        index > 0 {
+      contacts.remove(at: index)
+    }
+  }
+}
+

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -318,7 +318,7 @@ final class CreateBasicInfoViewModel {
   
   func updateContactType(for contact: ContactModel, newType: ContactModel.ContactType) {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }) {
-      contacts[index].type = newType
+      contacts[index] = ContactModel(type: newType, value: contact.value)
     }
   }
   


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-912](https://yapp25app3.atlassian.net/browse/PC-912)

## 👷🏼‍♂️ 변경 사항
### 작업 개요
프로필 생성/수정 화면의 연락처 필드 기능 전반을 개선하고 재사용 가능한 디자인 시스템 컴포넌트로 분리하였습니다.

### 주요 변경 사항
- `PCContactField` 컴포넌트 추가
    - 기존 작업자분이 만드신`PCTextEditor`를 사용하는 UI의 경우 연락처 타입에 따라 요구되는 UI를 구현할 수 없었습니다.
- 도메인 모델인 `ContactModel` 대신 `ContactDisplayModel`을 사용하여 `DesignSystem`에 정의
- `ContactDisplayModel`에 따라 `TextField` / `TextEditor`를 분기 처리하는 `ContactContainer` 추가
    - `.openKakao` 타입만 `TextEditor`이며 동적 높이 지원

### 기타 변경 사항
- 연락처 필드의 포커싱 및 키보드 버그 개선
- 연락처 추가/수정 시 자동 스크롤 및 포커싱 동작 처리
- 배경 터치 시 키보드 해제 로직 추가

## 💬 참고 사항
1.  최대한 기존 코드는 건드리지 않고 UI 쪽만 수정해서 이슈를 해결해 보았습니다...
2. 
- 아래 버그가 있어서 `PCConactField`내부 `TextEditor`에서는 `.pretendard()`를 사용하지 않고 `.font()`를 사용했습니다. 
- 동적으로 높이 변경 시에 lineSpacing 때문에 아래처럼 내부 text가 empty일때랑 아닐때에 따라서 높이가 알아서 바뀌네요 ㅠㅠ
- 우선.. pretendard를 수정할 필요는 없을 것 같고 TextEditor같은 예외사항에 대해서만 조심하면 될 것 같아 보입니다.

| text가 empty여부에 따른 레이아웃 변경 |
| :--: |
|![pretendard_bug](https://github.com/user-attachments/assets/ff849a41-735c-41ea-9d72-c45e5ef2bef7)
```swift
struct Pretendard: ViewModifier {
  let font: Fonts.Pretendard
  
  func body(content: Content) -> some View {
    content
      .font(font.swiftUIFont)
      .lineSpacing(font.lineHeight - font.uiFont.lineHeight) <-- 이 친구 때문에
      .padding(.vertical, (font.lineHeight - font.uiFont.lineHeight) / 2)
  }
}
```

3.
다음 작업은 연락처 중복 안되도록 ViewModel만 조금 손보면 될 것 같아요!

4.
최대한 작업을 쪼개서 해보려했는데 qa대응하려면 새로 만들어야해서 diff가 좀 많습니다 ㅜㅜ

5. 최대한 커밋단위로 리뷰하실 수 있게 작업해놓았습니다.

## 📸 스크린샷(Optional)
| 오픈카톡 | 나머지 |
| :--: | :--: |
| ![오픈카톡 개행](https://github.com/user-attachments/assets/ecd6766a-b23f-480f-bbf6-3c87252bd0db)  | ![나머지](https://github.com/user-attachments/assets/ad081d3b-0791-41a7-8ef2-178c7a1fabe3) |

[PC-912]: https://yapp25app3.atlassian.net/browse/PC-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ