### PR TITLE
[PC-911] Fix: 연락처 추가 시 연락처가 유일하게 추가된다

### DIFF
--- a/Domain/Entities/Sources/Profile/ContactModel.swift
+++ b/Domain/Entities/Sources/Profile/ContactModel.swift
@@ -25,7 +25,18 @@ public struct ContactModel: Hashable, Identifiable {
     self.value = value
   }
 }
+
 public extension ContactModel.ContactType {
+  var icon: String {
+    switch self {
+    case .kakao: return "kakao-32"
+    case .openKakao: return "kakao-openchat-32"
+    case .instagram: return "instagram-32"
+    case .phone: return "cell-fill-32"
+    default: return "unknown"
+    }
+  }
+
   static func from(iconName: String) -> ContactModel.ContactType {
     switch iconName {
     case "kakao-32": return .kakao

--- a/Domain/Entities/Sources/Profile/ContactModel.swift
+++ b/Domain/Entities/Sources/Profile/ContactModel.swift
@@ -25,3 +25,14 @@ public struct ContactModel: Hashable, Identifiable {
     self.value = value
   }
 }
+public extension ContactModel.ContactType {
+  static func from(iconName: String) -> ContactModel.ContactType {
+    switch iconName {
+    case "kakao-32": return .kakao
+    case "kakao-openchat-32": return .openKakao
+    case "instagram-32": return .instagram
+    case "cell-fill-32": return .phone
+    default: return .unknown
+    }
+  }
+}

--- a/Presentation/DesignSystem/Sources/PCBottomSheet.swift
+++ b/Presentation/DesignSystem/Sources/PCBottomSheet.swift
@@ -10,6 +10,109 @@ import SwiftUI
 public struct PCBottomSheet<Content: View>: View {
   @Binding var isPresented: Bool
   private var height: CGFloat = 300
+public protocol BottomSheetItemRepresentable: Hashable, Identifiable {
+  associatedtype Body: View
+  @ViewBuilder func render() -> Body
+  
+  var id: UUID { get }
+  var text: String { get }
+  var state: BottomSheetItemState { get }
+}
+
+public enum BottomSheetItemState {
+  case selected
+  case unselected
+  case disable
+  
+  var foregroundColor: Color {
+    switch self {
+    case .selected:
+      Color.primaryDefault
+    case .unselected:
+      Color.grayscaleBlack
+    case .disable:
+      Color.grayscaleDark3
+    }
+  }
+}
+
+public struct BottomSheetIconItem: BottomSheetItemRepresentable {
+  public var id: UUID = UUID()
+  public var text: String
+  public var state: BottomSheetItemState = .unselected
+  public var icon: String
+  
+  public func render() -> some View {
+    HStack {
+      DesignSystemImages(name: icon).swiftUIImage
+        .renderingMode(.template)
+        .foregroundStyle(state.foregroundColor)
+      Text(text)
+        .pretendard(.body_M_M)
+        .foregroundStyle(state.foregroundColor)
+      Spacer()
+      if state != .unselected {
+        DesignSystemAsset.Icons.check24.swiftUIImage
+          .renderingMode(.template)
+          .foregroundStyle(state.foregroundColor)
+      }
+    }
+    .frame(maxWidth: .infinity)
+  }
+  
+  public init(
+    id: UUID = UUID(),
+    text: String,
+    state: BottomSheetItemState = .unselected,
+    icon: String
+  ) {
+    self.id = id
+    self.text = text
+    self.state = state
+    self.icon = icon
+  }
+}
+
+extension BottomSheetIconItem {
+  public static let defaultContactItems: [BottomSheetIconItem] = [
+    .init(text: "카카오톡 아이디", icon: "kakao-32"),
+    .init(text: "카카오톡 오픈 채팅방", icon: "kakao-openchat-32"),
+    .init(text: "인스타 아이디", icon: "instagram-32"),
+    .init(text: "전화번호", icon: "cell-fill-32")
+  ]
+}
+
+public struct BottomSheetTextItem: BottomSheetItemRepresentable {
+  public var id: UUID
+  public var text: String
+  public var state: BottomSheetItemState = .unselected
+  
+  public func render() -> some View {
+    HStack {
+      Text(text)
+        .pretendard(.body_M_M)
+        .foregroundStyle(state.foregroundColor)
+      Spacer()
+      if state == .selected {
+        DesignSystemAsset.Icons.check24.swiftUIImage
+          .renderingMode(.template)
+          .foregroundStyle(state.foregroundColor)
+      }
+    }
+    .frame(maxWidth: .infinity)
+  }
+  
+  public init(
+    id: UUID = UUID(),
+    text: String,
+    state: BottomSheetItemState = .unselected
+  ) {
+    self.id = id
+    self.text = text
+    self.state = state
+  }
+}
+
   private let titleText: String
   private let subtitleText: String?
   private let buttonText: String

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -86,7 +86,6 @@ struct EditProfileView: View {
                 }
                 .foregroundStyle(Color.primaryDefault)
               }
-    
               .opacity(viewModel.canAddMoreContact ? 1 : 0)
               .disabled(!viewModel.canAddMoreContact)
             }
@@ -511,8 +510,7 @@ fileprivate struct EditContactContainer: View {
         PCContactField(
           contact: bindingForContact(id: contact.id),
           action: {
-            viewModel.selectedContactForIconChange = contact
-            viewModel.isContactTypeChangeSheetPresented = true
+            viewModel.handleAction(.tapChangeContact(contact))
           }
         )
         .focused(focusField, equals: "contact_\(contact.id)")

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -76,7 +76,7 @@ struct EditProfileView: View {
               
               Button {
                 focusField = nil
-                viewModel.isSNSSheetPresented = true
+                viewModel.handleAction(.tapAddContact)
               } label: {
                 HStack(spacing: 4) {
                   Text("연락처 추가하기")

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -87,6 +87,8 @@ struct EditProfileView: View {
                 .foregroundStyle(Color.primaryDefault)
               }
     
+              .opacity(viewModel.canAddMoreContact ? 1 : 0)
+              .disabled(!viewModel.canAddMoreContact)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 260)

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -332,7 +332,7 @@ struct EditProfileView: View {
     .disabled(true)
     .onTapGesture {
       focusField = nil
-      viewModel.isLocationSheetPresented = true
+      viewModel.handleAction(.tapLocation)
     }
   }
   
@@ -387,7 +387,7 @@ struct EditProfileView: View {
     .disabled(true)
     .onTapGesture {
       focusField = nil
-      viewModel.isJobSheetPresented = true
+      viewModel.handleAction(.tapJob)
     }
     .onChange(of: viewModel.job) { _, _
       in viewModel.isEditing = true

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -110,15 +110,6 @@ struct EditProfileView: View {
       }
       .ignoresSafeArea(.keyboard)
       
-      if viewModel.isJobSheetPresented {
-        jobBottomSheet
-      }
-      if viewModel.isLocationSheetPresented {
-        locationBottomSheet
-      }
-      if viewModel.isSNSSheetPresented || viewModel.isContactTypeChangeSheetPresented {
-        snsBottomSheet
-      }
       VStack {
         Spacer()
         if viewModel.showToast {
@@ -130,6 +121,53 @@ struct EditProfileView: View {
       }
     }
     .toolbar(.hidden, for: .navigationBar)
+    .sheet(isPresented: $viewModel.isLocationSheetPresented) {
+      PCBottomSheet<BottomSheetTextItem>(
+        isButtonEnabled: .constant(true),
+        items: $viewModel.locationItems,
+        titleText: "활동 지역",
+        subtitleText: "주로 활동하는 지역을 선택해주세요.",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.saveLocation) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(602)])
+    }
+    .sheet(isPresented: $viewModel.isJobSheetPresented) {
+      PCBottomSheet<BottomSheetTextItem>(
+        isButtonEnabled: .constant(true),
+        items: $viewModel.jobItems,
+        titleText: "직업",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.saveJob) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(562)])
+    }
+    .sheet(isPresented: $viewModel.isSNSSheetPresented) {
+      PCBottomSheet<BottomSheetIconItem>(
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
+        items: $viewModel.contactBottomSheetItems,
+        titleText: "연락처",
+        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.saveContact) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(458)])
+    }
+    .sheet(isPresented: $viewModel.isContactTypeChangeSheetPresented) {
+      PCBottomSheet<BottomSheetIconItem>(
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
+        items: $viewModel.contactBottomSheetItems,
+        titleText: "연락처",
+        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.editContact) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(458)])
+    }
   }
   
   private var navigationBar: some View {
@@ -414,165 +452,6 @@ struct EditProfileView: View {
         .foregroundStyle(Color.grayscaleDark3)
       
       EditContactContainer(viewModel: viewModel, focusField: $focusField)
-    }
-  }
-  
-  private var locationBottomSheet: some View {
-    func makeLocationCell(_ location: String) -> some View {
-      VStack(alignment: .leading, spacing: 0) {
-        cellItem(
-          text: location,
-          isSelected: viewModel.selectedLocation == location,
-          action: {
-            viewModel.isEditing = true
-            viewModel.selectedLocation = location
-          }
-        )
-      }
-    }
-    
-    return PCBottomSheet(
-      isPresented: $viewModel.isLocationSheetPresented,
-      height: 623,
-      titleText: "활동지역 선택",
-      buttonText: "저장하기",
-      buttonAction: { viewModel.saveSelectedLocation() }
-    ) {
-      ScrollView {
-        VStack(alignment: .leading, spacing: 0) {
-          ForEach(viewModel.locations, id: \.self) { location in
-            makeLocationCell(location)
-          }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-      }
-    }
-  }
-  
-  private var jobBottomSheet: some View {
-    func makeJobCell(_ job: String) -> some View {
-      VStack(alignment: .leading, spacing: 0) {
-        cellItem(
-          text: job,
-          isSelected: job == "기타" ? viewModel.isCustomJobSelected : viewModel.selectedJob == job,
-          action: {
-            viewModel.isEditing = true
-            if job == "기타" {
-              viewModel.isCustomJobSelected = true
-              viewModel.selectedJob = nil
-            } else {
-              viewModel.isCustomJobSelected = false
-              viewModel.selectedJob = job
-            }
-          }
-        )
-        
-        if job == "기타" && viewModel.isCustomJobSelected {
-          PCTextField(
-            title: "",
-            text: $viewModel.customJobText,
-            focusState: $focusField,
-            focusField: "customJob"
-          )
-          .padding(.horizontal)
-          .padding(.vertical, 8)
-        }
-      }
-    }
-    
-    return PCBottomSheet(
-      isPresented: $viewModel.isJobSheetPresented,
-      height: 431,
-      titleText: "직업 선택",
-      buttonText: "저장하기",
-      buttonAction: { viewModel.saveSelectedJob() }
-    ) {
-      ScrollView {
-        VStack(alignment: .leading, spacing: 0) {
-          ForEach(viewModel.jobs, id: \.self) { job in
-            makeJobCell(job)
-          }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-      }
-    }
-  }
-  
-  private var snsBottomSheet: some View {
-    PCBottomSheet(
-      isPresented:  Binding(
-        get: { viewModel.isSNSSheetPresented || viewModel.isContactTypeChangeSheetPresented },
-        set: { isPresented in
-          viewModel.isSNSSheetPresented = isPresented
-          viewModel.isContactTypeChangeSheetPresented = isPresented
-        }
-      ),
-      height: 479,
-      titleText: "연락처 추가",
-      subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
-      buttonText: "추가하기",
-      buttonAction: {
-        viewModel.saveSelectedSNSItem()
-      }
-    ) {
-      VStack(alignment: .leading) {
-        cellItem(
-          image: DesignSystemAsset.Icons.kakao32.swiftUIImage,
-          text: "카카오톡 아이디",
-          isSelected: viewModel.selectedSNSContactType == .kakao,
-          action: { viewModel.selectedSNSContactType = .kakao  }
-        )
-        cellItem(
-          image: DesignSystemAsset.Icons.kakaoOpenchat32.swiftUIImage,
-          text: "카카오톡 오픈 채팅방",
-          isSelected: viewModel.selectedSNSContactType == .openKakao,
-          action: { viewModel.selectedSNSContactType = .openKakao }
-        )
-        cellItem(
-          image: DesignSystemAsset.Icons.instagram32.swiftUIImage,
-          text: "인스타 아이디",
-          isSelected: viewModel.selectedSNSContactType == .instagram,
-          action: { viewModel.selectedSNSContactType = .instagram }
-        )
-        cellItem(
-          image: DesignSystemAsset.Icons.cellFill32.swiftUIImage,
-          text: "전화번호",
-          isSelected: viewModel.selectedSNSContactType == .phone,
-          action: { viewModel.selectedSNSContactType = .phone }
-        )
-      }
-      .frame(maxWidth: .infinity, alignment: .leading)
-    }
-    .onAppear {
-      focusField = nil
-    }
-  }
-  
-  private func cellItem(
-    image: Image? = nil,
-    text: String,
-    isSelected: Bool = false,
-    action: @escaping () -> Void
-  ) -> some View {
-    Button(action: action) {
-      HStack {
-        if let image {
-          image
-            .renderingMode(.template)
-            .foregroundStyle(isSelected ? Color.primaryDefault : Color.grayscaleBlack)
-        }
-        Text(text)
-          .pretendard(.body_M_M)
-          .foregroundStyle(isSelected ? Color.primaryDefault : Color.grayscaleBlack)
-        Spacer()
-        if isSelected {
-          DesignSystemAsset.Icons.check24.swiftUIImage
-            .renderingMode(.template)
-            .foregroundStyle(Color.primaryDefault)
-        }
-      }
-      .padding(.vertical, 12)
-      .frame(maxWidth: .infinity)
     }
   }
   

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -21,6 +21,7 @@ final class EditProfileViewModel {
     case tapVaildNickName
     case selectCamera
     case selectPhotoLibrary
+    case tapAddContact
   }
   
   init(
@@ -248,6 +249,9 @@ final class EditProfileViewModel {
       Task {
         await handleTapVaildNicknameButton()
       }
+    case .tapAddContact:
+      isSNSSheetPresented = true
+      updateBottomSheetItems()
     }
   }
   
@@ -445,6 +449,20 @@ extension EditProfileViewModel {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }),
        index > 0 {
       removeContact(at: index)
+  func updateBottomSheetItems() {
+    contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
+      var copy = item
+      let type = ContactModel.ContactType.from(iconName: item.icon)
+      
+      if contacts.contains(where: { $0.type == type }) {
+        copy.state = .disable
+      } else {
+        copy.state = .unselected
+      }
+      
+      return copy
+    }
+  }
     }
   }
 // MARK: Constant

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -457,6 +457,12 @@ extension EditProfileViewModel {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }),
        index > 0 {
       removeContact(at: index)
+  var isContactBottomSheetButtonEnable: Bool {
+      contactBottomSheetItems.contains(where: { $0.state == .selected })
+  }
+}
+
+
 // MARK: - Mutation
 
 extension EditProfileViewModel {
@@ -484,6 +490,17 @@ extension EditProfileViewModel {
       return copy
     }
   }
+  
+  func tapRowItem(_ item: any BottomSheetItemRepresentable) {
+    if let index = contactBottomSheetItems.firstIndex(where: { $0.id == item.id }),
+       item.state == .unselected {
+      contactBottomSheetItems.enumerated().forEach { (i, item) in
+        if contactBottomSheetItems[i].state == .unselected, i == index {
+          contactBottomSheetItems[i].state = .selected
+        } else if contactBottomSheetItems[i].state == .selected {
+          contactBottomSheetItems[i].state = .unselected
+        }
+      }
     }
   }
 }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -23,6 +23,7 @@ final class EditProfileViewModel {
     case selectPhotoLibrary
     case tapAddContact
     case tapChangeContact(ContactModel)
+    case saveContact
   }
   
   init(
@@ -260,6 +261,8 @@ final class EditProfileViewModel {
       updateBottomSheetItems()
       changeBottomSheetItem(with: prevContact)
       prevSelectedContact = prevContact
+    case .saveContact:
+      tapContactBottomSheetSaveButton()
     }
   }
   
@@ -503,6 +506,19 @@ extension EditProfileViewModel {
       }
     }
   }
+  func tapContactBottomSheetSaveButton() {
+    if let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
+      let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)
+      
+      if newType != .unknown {
+        let newContact = ContactModel(type: newType, value: "")
+        contacts.append(newContact)
+      }
+    }
+
+    isSNSSheetPresented = false
+  }
+
 }
 
 // MARK: Constant

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -21,8 +21,12 @@ final class EditProfileViewModel {
     case tapVaildNickName
     case selectCamera
     case selectPhotoLibrary
+    case tapLocation
+    case tapJob
     case tapAddContact
     case tapChangeContact(ContactModel)
+    case saveLocation
+    case saveJob
     case saveContact
     case editContact
   }
@@ -203,8 +207,9 @@ final class EditProfileViewModel {
   var didCheckDuplicates: Bool = true
   var didTapnextButton: Bool = false
   
-  var locations: [String] = Locations.all
+  var locationItems: [BottomSheetTextItem] = Locations.all.map { BottomSheetTextItem(text: $0) }
   var jobs: [String] = Jobs.all
+  var jobItems: [BottomSheetTextItem] = Jobs.all.map { BottomSheetTextItem(text: $0) }
   var contactBottomSheetItems: [BottomSheetIconItem] = BottomSheetIconItem.defaultContactItems
   
   // Sheet
@@ -254,6 +259,10 @@ final class EditProfileViewModel {
       Task {
         await handleTapVaildNicknameButton()
       }
+    case .tapLocation:
+      isLocationSheetPresented = true
+    case .tapJob:
+      isJobSheetPresented = true
     case .tapAddContact:
       isSNSSheetPresented = true
       updateBottomSheetItems()
@@ -262,6 +271,10 @@ final class EditProfileViewModel {
       updateBottomSheetItems()
       changeBottomSheetItem(with: prevContact)
       prevSelectedContact = prevContact
+    case .saveLocation:
+      tapLocationBottomSheetSaveButton()
+    case .saveJob:
+      tapJobBottomSheetSaveButton()
     case .saveContact:
       tapContactBottomSheetSaveButton()
     case .editContact:
@@ -539,6 +552,13 @@ extension EditProfileViewModel {
     isSNSSheetPresented = false
   }
 
+  func tapLocationBottomSheetSaveButton() {
+    // TODO: location 적용 로직
+  }
+  
+  func tapJobBottomSheetSaveButton() {
+    // TODO: job 적용 로직
+  }
 }
 
 // MARK: Constant

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -24,6 +24,7 @@ final class EditProfileViewModel {
     case tapAddContact
     case tapChangeContact(ContactModel)
     case saveContact
+    case editContact
   }
   
   init(
@@ -263,6 +264,8 @@ final class EditProfileViewModel {
       prevSelectedContact = prevContact
     case .saveContact:
       tapContactBottomSheetSaveButton()
+    case .editContact:
+      tapContactBottomSheetEditButton()
     }
   }
   
@@ -506,6 +509,23 @@ extension EditProfileViewModel {
       }
     }
   }
+  
+  func tapContactBottomSheetEditButton() {
+    if let prevSelectedContact,
+       let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
+      let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)
+      
+      if newType != .unknown,
+         let targetIndex = contacts.firstIndex(where: { $0.id == prevSelectedContact.id }) {
+        let changedContact = ContactModel(type: newType, value: prevSelectedContact.value)
+        contacts[targetIndex] = changedContact
+      }
+    }
+
+    prevSelectedContact = nil
+    isContactTypeChangeSheetPresented = false
+  }
+
   func tapContactBottomSheetSaveButton() {
     if let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
       let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -22,6 +22,7 @@ final class EditProfileViewModel {
     case selectCamera
     case selectPhotoLibrary
     case tapAddContact
+    case tapChangeContact(ContactModel)
   }
   
   init(
@@ -194,6 +195,7 @@ final class EditProfileViewModel {
   var isCustomJobSelected: Bool = false
   var selectedSNSContactType: ContactModel.ContactType? = nil
   var selectedContactForIconChange: ContactModel? = nil
+  var prevSelectedContact: ContactModel? = nil
   var isContactTypeChangeSheetPresented: Bool = false
   var selectedItem: PhotosPickerItem? = nil
   var didCheckDuplicates: Bool = true
@@ -201,6 +203,7 @@ final class EditProfileViewModel {
   
   var locations: [String] = Locations.all
   var jobs: [String] = Jobs.all
+  var contactBottomSheetItems: [BottomSheetIconItem] = BottomSheetIconItem.defaultContactItems
   
   // Sheet
   var isPhotoSheetPresented: Bool = false
@@ -252,6 +255,11 @@ final class EditProfileViewModel {
     case .tapAddContact:
       isSNSSheetPresented = true
       updateBottomSheetItems()
+    case .tapChangeContact(let prevContact):
+      isContactTypeChangeSheetPresented = true
+      updateBottomSheetItems()
+      changeBottomSheetItem(with: prevContact)
+      prevSelectedContact = prevContact
     }
   }
   
@@ -449,6 +457,19 @@ extension EditProfileViewModel {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }),
        index > 0 {
       removeContact(at: index)
+// MARK: - Mutation
+
+extension EditProfileViewModel {
+  func changeBottomSheetItem(with targetContact: ContactModel) {
+    if let contactIndex = contacts.firstIndex(where: { $0.id == targetContact.id }) {
+      let targetIcon = contacts[contactIndex].type.icon
+      
+      if let itemIndex = contactBottomSheetItems.firstIndex(where: { $0.icon == targetIcon }) {
+        contactBottomSheetItems[itemIndex].state = .selected
+      }
+    }
+  }
+  
   func updateBottomSheetItems() {
     contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
       var copy = item
@@ -465,6 +486,8 @@ extension EditProfileViewModel {
   }
     }
   }
+}
+
 // MARK: Constant
 extension EditProfileViewModel {
   private enum Constant {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -227,6 +227,9 @@ final class EditProfileViewModel {
       }
     }
   }
+  var canAddMoreContact: Bool {
+    contacts.count < Constant.contactModelCount
+  }
   var isSNSSheetPresented: Bool = false
   var isProfileImageSheetPresented: Bool = false
   var showToast: Bool = false
@@ -443,5 +446,10 @@ extension EditProfileViewModel {
        index > 0 {
       removeContact(at: index)
     }
+  }
+// MARK: Constant
+extension EditProfileViewModel {
+  private enum Constant {
+    static let contactModelCount: Int = 4
   }
 }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -189,8 +189,6 @@ final class EditProfileViewModel {
       return ""
     }
   }
-  var contactInfoText: String = ""
-  var showAdditionalContactError: Bool = false
   
   // temp
   var smokingStatus: String = ""
@@ -200,7 +198,6 @@ final class EditProfileViewModel {
   var customJobText: String = ""
   var isCustomJobSelected: Bool = false
   var selectedSNSContactType: ContactModel.ContactType? = nil
-  var selectedContactForIconChange: ContactModel? = nil
   var prevSelectedContact: ContactModel? = nil
   var isContactTypeChangeSheetPresented: Bool = false
   var selectedItem: PhotosPickerItem? = nil
@@ -374,31 +371,6 @@ final class EditProfileViewModel {
     }
   }
   
-  func saveSelectedSNSItem() {
-    if let selectedType = selectedSNSContactType {
-      if let contact = selectedContactForIconChange {
-        // 아이콘 변경 시 처리
-        updateContactType(for: contact, newType: selectedType)
-      } else {
-        // 새 연락처 추가 시 처리
-        contacts.append(ContactModel(type: selectedType, value: ""))
-        isEditing = true
-      }
-    }
-    
-    // 상태 초기화
-    isSNSSheetPresented = false
-    isContactTypeChangeSheetPresented = false
-    selectedSNSContactType = nil
-    selectedContactForIconChange = nil
-  }
-  
-  func removeContact(at index: Int) {
-    guard contacts.indices.contains(index), index != 0 else { return }
-    contacts.remove(at: index)
-    isEditing = true
-  }
-  
   func loadImage() async {
     guard let selectedItem else {
       print("선택된 아이템이 없습니다.")
@@ -475,7 +447,10 @@ extension EditProfileViewModel {
   func removeContact(for contact: ContactModel) {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }),
        index > 0 {
-      removeContact(at: index)
+      contacts.remove(at: index)
+    }
+  }
+  
   var isContactBottomSheetButtonEnable: Bool {
       contactBottomSheetItems.contains(where: { $0.state == .selected })
   }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -114,7 +114,6 @@ struct CreateBasicInfoView: View {
                 }
                 .foregroundStyle(Color.primaryDefault)
               }
-    
               .opacity(viewModel.canAddMoreContact ? 1 : 0)
               .disabled(!viewModel.canAddMoreContact)
             }
@@ -506,8 +505,7 @@ fileprivate struct CreateContactContainer: View {
         PCContactField(
           contact: bindingForContact(id: contact.id),
           action: {
-            viewModel.selectedContactForIconChange = contact
-            viewModel.isContactTypeChangeSheetPresented = true
+            viewModel.handleAction(.tapChangeContact(contact))
           }
         )
         .focused(focusField, equals: "contact_\(contact.id)")

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -142,15 +142,6 @@ struct CreateBasicInfoView: View {
       }
       .ignoresSafeArea(.keyboard)
       
-      if viewModel.isJobSheetPresented {
-        jobBottomSheet
-      }
-      if viewModel.isLocationSheetPresented {
-        locationBottomSheet
-      }
-      if viewModel.isSNSSheetPresented || viewModel.isContactTypeChangeSheetPresented {
-        snsBottomSheet
-      }
       VStack {
         Spacer()
         if viewModel.showToast {
@@ -160,6 +151,53 @@ struct CreateBasicInfoView: View {
             .animation(.easeInOut(duration: 0.5), value: viewModel.showToast)
         }
       }
+    }
+    .sheet(isPresented: $viewModel.isLocationSheetPresented) {
+      PCBottomSheet<BottomSheetTextItem>(
+        isButtonEnabled: .constant(true),
+        items: $viewModel.locationItems,
+        titleText: "활동 지역",
+        subtitleText: "주로 활동하는 지역을 선택해주세요.",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.saveLocation) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(602)])
+    }
+    .sheet(isPresented: $viewModel.isJobSheetPresented) {
+      PCBottomSheet<BottomSheetTextItem>(
+        isButtonEnabled: .constant(true),
+        items: $viewModel.jobItems,
+        titleText: "직업",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.saveJob) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(562)])
+    }
+    .sheet(isPresented: $viewModel.isSNSSheetPresented) {
+      PCBottomSheet<BottomSheetIconItem>(
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
+        items: $viewModel.contactBottomSheetItems,
+        titleText: "연락처",
+        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.saveContact) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(458)])
+    }
+    .sheet(isPresented: $viewModel.isContactTypeChangeSheetPresented) {
+      PCBottomSheet<BottomSheetIconItem>(
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
+        items: $viewModel.contactBottomSheetItems,
+        titleText: "연락처",
+        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        buttonText: "적용하기",
+        buttonAction: { viewModel.handleAction(.editContact) },
+        onTapRowItem: { viewModel.tapRowItem($0) }
+      )
+      .presentationDetents([.height(458)])
     }
   }
   
@@ -410,161 +448,6 @@ struct CreateBasicInfoView: View {
         }
       }
     )
-  }
-  
-  private var locationBottomSheet: some View {
-    func makeLocationCell(_ location: String) -> some View {
-      VStack(alignment: .leading, spacing: 0) {
-        cellItem(
-          text: location,
-          isSelected: viewModel.selectedLocation == location,
-          action: { viewModel.selectedLocation = location }
-        )
-      }
-    }
-    
-    return PCBottomSheet(
-      isPresented: $viewModel.isLocationSheetPresented,
-      height: 623,
-      titleText: "활동지역 선택",
-      buttonText: "저장하기",
-      buttonAction: { viewModel.saveSelectedLocation() }
-    ) {
-      ScrollView {
-        VStack(alignment: .leading, spacing: 0) {
-          ForEach(viewModel.locations, id: \.self) { location in
-            makeLocationCell(location)
-          }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-      }
-    }
-  }
-  
-  private var jobBottomSheet: some View {
-    func makeJobCell(_ job: String) -> some View {
-      VStack(alignment: .leading, spacing: 0) {
-        cellItem(
-          text: job,
-          isSelected: job == "기타" ? viewModel.isCustomJobSelected : viewModel.selectedJob == job,
-          action: {
-            if job == "기타" {
-              viewModel.isCustomJobSelected = true
-              viewModel.selectedJob = nil
-            } else {
-              viewModel.isCustomJobSelected = false
-              viewModel.selectedJob = job
-            }
-          }
-        )
-        
-        if job == "기타" && viewModel.isCustomJobSelected {
-          PCTextField(
-            title: "",
-            text: $viewModel.customJobText,
-            focusState: $focusField,
-            focusField: "customJob"
-          )
-          .padding(.horizontal)
-          .padding(.vertical, 8)
-        }
-      }
-    }
-    
-    return PCBottomSheet(
-      isPresented: $viewModel.isJobSheetPresented,
-      height: 431,
-      titleText: "직업 선택",
-      buttonText: "저장하기",
-      buttonAction: { viewModel.saveSelectedJob() }
-    ) {
-      ScrollView {
-        VStack(alignment: .leading, spacing: 0) {
-          ForEach(viewModel.jobs, id: \.self) { job in
-            makeJobCell(job)
-          }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-      }
-    }
-  }
-  
-  private var snsBottomSheet: some View {
-    PCBottomSheet(
-      isPresented:  Binding(
-        get: { viewModel.isSNSSheetPresented || viewModel.isContactTypeChangeSheetPresented },
-        set: { isPresented in
-          viewModel.isSNSSheetPresented = isPresented
-          viewModel.isContactTypeChangeSheetPresented = isPresented
-        }
-      ),
-      height: 479,
-      titleText: "연락처 추가",
-      subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
-      buttonText: "추가하기",
-      buttonAction: {
-        viewModel.saveSelectedSNSItem()
-      }
-    ) {
-      VStack(alignment: .leading) {
-        cellItem(
-          image: DesignSystemAsset.Icons.kakao32.swiftUIImage,
-          text: "카카오톡 아이디",
-          isSelected: viewModel.selectedSNSContactType == .kakao,
-          action: { viewModel.selectedSNSContactType = .kakao  }
-        )
-        cellItem(
-          image: DesignSystemAsset.Icons.kakaoOpenchat32.swiftUIImage,
-          text: "카카오톡 오픈 채팅방",
-          isSelected: viewModel.selectedSNSContactType == .openKakao,
-          action: { viewModel.selectedSNSContactType = .openKakao }
-        )
-        cellItem(
-          image: DesignSystemAsset.Icons.instagram32.swiftUIImage,
-          text: "인스타 아이디",
-          isSelected: viewModel.selectedSNSContactType == .instagram,
-          action: { viewModel.selectedSNSContactType = .instagram }
-        )
-        cellItem(
-          image: DesignSystemAsset.Icons.cellFill32.swiftUIImage,
-          text: "전화번호",
-          isSelected: viewModel.selectedSNSContactType == .phone,
-          action: { viewModel.selectedSNSContactType = .phone }
-        )
-      }
-      .frame(maxWidth: .infinity, alignment: .leading)
-    }
-    .onAppear {
-      focusField = nil
-    }
-  }
-
-  private func cellItem(
-    image: Image? = nil,
-    text: String,
-    isSelected: Bool = false,
-    action: @escaping () -> Void
-  ) -> some View {
-    Button(action: action) {
-      HStack {
-        if let image {
-          image
-            .renderingMode(.template)
-            .foregroundStyle(isSelected ? Color.primaryDefault : Color.grayscaleBlack)
-        }
-        Text(text)
-          .pretendard(.body_M_M)
-          .foregroundStyle(isSelected ? Color.primaryDefault : Color.grayscaleBlack)
-        Spacer()
-        if isSelected {
-          DesignSystemAsset.Icons.check24.swiftUIImage
-            .renderingMode(.template)
-            .foregroundStyle(Color.primaryDefault)
-        }
-      }
-      .padding(.vertical, 12)
-      .frame(maxWidth: .infinity)
-    }
   }
   
   private var toast: some View {

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -115,6 +115,8 @@ struct CreateBasicInfoView: View {
                 .foregroundStyle(Color.primaryDefault)
               }
     
+              .opacity(viewModel.canAddMoreContact ? 1 : 0)
+              .disabled(!viewModel.canAddMoreContact)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 200)

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -322,7 +322,7 @@ struct CreateBasicInfoView: View {
     .disabled(true)
     .onTapGesture {
       focusField = nil
-      viewModel.isLocationSheetPresented = true
+      viewModel.handleAction(.tapLocation)
     }
   }
   
@@ -375,7 +375,7 @@ struct CreateBasicInfoView: View {
     .disabled(true)
     .onTapGesture {
       focusField = nil
-      viewModel.isJobSheetPresented = true
+      viewModel.handleAction(.tapJob)
     }
   }
   

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -104,7 +104,7 @@ struct CreateBasicInfoView: View {
               
               Button {
                 focusField = nil
-                viewModel.isSNSSheetPresented = true
+                viewModel.handleAction(.tapAddContact)
               } label: {
                 HStack(spacing: 4) {
                   Text("연락처 추가하기")

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -20,8 +20,12 @@ final class CreateBasicInfoViewModel {
     case tapVaildNickName
     case selectCamera
     case selectPhotoLibrary
+    case tapLocation
+    case tapJob
     case tapAddContact
     case tapChangeContact(ContactModel)
+    case saveLocation
+    case saveJob
     case saveContact
     case editContact
   }
@@ -184,8 +188,9 @@ final class CreateBasicInfoViewModel {
   var didCheckDuplicates: Bool = false
   var didTapnextButton: Bool = false
   
-  var locations: [String] = Locations.all
+  var locationItems: [BottomSheetTextItem] = Locations.all.map { BottomSheetTextItem(text: $0) }
   var jobs: [String] = Jobs.all
+  var jobItems: [BottomSheetTextItem] = Jobs.all.map { BottomSheetTextItem(text: $0) }
   var contactBottomSheetItems: [BottomSheetIconItem] = BottomSheetIconItem.defaultContactItems
   
   // Sheet
@@ -235,6 +240,10 @@ final class CreateBasicInfoViewModel {
       Task {
         await handleTapVaildNicknameButton()
       }
+    case .tapLocation:
+      isLocationSheetPresented = true
+    case .tapJob:
+      isJobSheetPresented = true
     case .tapAddContact:
       isSNSSheetPresented = true
       updateBottomSheetItems()
@@ -243,6 +252,10 @@ final class CreateBasicInfoViewModel {
       updateBottomSheetItems()
       changeBottomSheetItem(with: prevContact)
       prevSelectedContact = prevContact
+    case .saveLocation:
+      tapLocationBottomSheetSaveButton()
+    case .saveJob:
+      tapJobBottomSheetSaveButton()
     case .saveContact:
       tapContactBottomSheetSaveButton()
     case .editContact:
@@ -481,6 +494,17 @@ extension CreateBasicInfoViewModel {
     isSNSSheetPresented = false
   }
   
+  func tapLocationBottomSheetSaveButton() {
+    // TODO: location 적용 로직
+    
+    isLocationSheetPresented = true
+  }
+  
+  func tapJobBottomSheetSaveButton() {
+    // TODO: job 적용 로직
+    
+    isJobSheetPresented = true
+  }
 }
 
 // MARK: Constant

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -400,6 +400,12 @@ extension CreateBasicInfoViewModel {
       contacts.remove(at: index)
     }
   }
+  
+  var isContactBottomSheetButtonEnable: Bool {
+      contactBottomSheetItems.contains(where: { $0.state == .selected })
+  }
+}
+
 // MARK: - Mutation
 
 extension CreateBasicInfoViewModel {
@@ -424,6 +430,19 @@ extension CreateBasicInfoViewModel {
       }
       
       return copy
+    }
+  }
+  
+  func tapRowItem(_ item: any BottomSheetItemRepresentable) {
+    if let index = contactBottomSheetItems.firstIndex(where: { $0.id == item.id }),
+       item.state == .unselected {
+      contactBottomSheetItems.enumerated().forEach { (i, item) in
+        if contactBottomSheetItems[i].state == .unselected, i == index {
+          contactBottomSheetItems[i].state = .selected
+        } else if contactBottomSheetItems[i].state == .selected {
+          contactBottomSheetItems[i].state = .unselected
+        }
+      }
     }
   }
 }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -22,6 +22,7 @@ final class CreateBasicInfoViewModel {
     case selectPhotoLibrary
     case tapAddContact
     case tapChangeContact(ContactModel)
+    case saveContact
   }
   
   init(
@@ -241,6 +242,8 @@ final class CreateBasicInfoViewModel {
       updateBottomSheetItems()
       changeBottomSheetItem(with: prevContact)
       prevSelectedContact = prevContact
+    case .saveContact:
+      tapContactBottomSheetSaveButton()
     }
   }
   
@@ -445,6 +448,19 @@ extension CreateBasicInfoViewModel {
       }
     }
   }
+  func tapContactBottomSheetSaveButton() {
+    if let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
+      let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)
+      
+      if newType != .unknown {
+        let newContact = ContactModel(type: newType, value: "")
+        contacts.append(newContact)
+      }
+    }
+
+    isSNSSheetPresented = false
+  }
+  
 }
 
 // MARK: Constant

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -208,6 +208,9 @@ final class CreateBasicInfoViewModel {
       }
     }
   }
+  var canAddMoreContact: Bool {
+    contacts.count < Constant.contactModelCount
+  }
   var isSNSSheetPresented: Bool = false
   var isProfileImageSheetPresented: Bool = false
   var showToast: Bool = false
@@ -387,3 +390,8 @@ extension CreateBasicInfoViewModel {
   }
 }
 
+// MARK: Constant
+extension CreateBasicInfoViewModel {
+  private enum Constant {
+    static let contactModelCount: Int = 4
+  }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -21,6 +21,7 @@ final class CreateBasicInfoViewModel {
     case selectCamera
     case selectPhotoLibrary
     case tapAddContact
+    case tapChangeContact(ContactModel)
   }
   
   init(
@@ -175,6 +176,7 @@ final class CreateBasicInfoViewModel {
   var isCustomJobSelected: Bool = false
   var selectedSNSContactType: ContactModel.ContactType? = nil
   var selectedContactForIconChange: ContactModel? = nil
+  var prevSelectedContact: ContactModel? = nil
   var isContactTypeChangeSheetPresented: Bool = false
   var selectedItem: PhotosPickerItem? = nil
   var didCheckDuplicates: Bool = false
@@ -182,6 +184,7 @@ final class CreateBasicInfoViewModel {
   
   var locations: [String] = Locations.all
   var jobs: [String] = Jobs.all
+  var contactBottomSheetItems: [BottomSheetIconItem] = BottomSheetIconItem.defaultContactItems
   
   // Sheet
   var isPhotoSheetPresented: Bool = false
@@ -233,6 +236,11 @@ final class CreateBasicInfoViewModel {
     case .tapAddContact:
       isSNSSheetPresented = true
       updateBottomSheetItems()
+    case .tapChangeContact(let prevContact):
+      isContactTypeChangeSheetPresented = true
+      updateBottomSheetItems()
+      changeBottomSheetItem(with: prevContact)
+      prevSelectedContact = prevContact
     }
   }
   
@@ -392,6 +400,18 @@ extension CreateBasicInfoViewModel {
       contacts.remove(at: index)
     }
   }
+// MARK: - Mutation
+
+extension CreateBasicInfoViewModel {
+  func changeBottomSheetItem(with targetContact: ContactModel) {
+    if let contactIndex = contacts.firstIndex(where: { $0.id == targetContact.id }) {
+      let targetIcon = contacts[contactIndex].type.icon
+      if let itemIndex = contactBottomSheetItems.firstIndex(where: { $0.icon == targetIcon }) {
+        contactBottomSheetItems[itemIndex].state = .selected
+      }
+    }
+  }
+  
   func updateBottomSheetItems() {
     contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
       var copy = item
@@ -413,3 +433,4 @@ extension CreateBasicInfoViewModel {
   private enum Constant {
     static let contactModelCount: Int = 4
   }
+}

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -23,6 +23,7 @@ final class CreateBasicInfoViewModel {
     case tapAddContact
     case tapChangeContact(ContactModel)
     case saveContact
+    case editContact
   }
   
   init(
@@ -244,6 +245,8 @@ final class CreateBasicInfoViewModel {
       prevSelectedContact = prevContact
     case .saveContact:
       tapContactBottomSheetSaveButton()
+    case .editContact:
+      tapContactBottomSheetEditButton()
     }
   }
   
@@ -448,6 +451,23 @@ extension CreateBasicInfoViewModel {
       }
     }
   }
+  
+  func tapContactBottomSheetEditButton() {
+    if let prevSelectedContact,
+       let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
+      let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)
+      
+      if newType != .unknown,
+         let targetIndex = contacts.firstIndex(where: { $0.id == prevSelectedContact.id }) {
+        let changedContact = ContactModel(type: newType, value: prevSelectedContact.value)
+        contacts[targetIndex] = changedContact
+      }
+    }
+
+    prevSelectedContact = nil
+    isContactTypeChangeSheetPresented = false
+  }
+
   func tapContactBottomSheetSaveButton() {
     if let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
       let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -20,6 +20,7 @@ final class CreateBasicInfoViewModel {
     case tapVaildNickName
     case selectCamera
     case selectPhotoLibrary
+    case tapAddContact
   }
   
   init(
@@ -229,6 +230,9 @@ final class CreateBasicInfoViewModel {
       Task {
         await handleTapVaildNicknameButton()
       }
+    case .tapAddContact:
+      isSNSSheetPresented = true
+      updateBottomSheetItems()
     }
   }
   
@@ -386,6 +390,20 @@ extension CreateBasicInfoViewModel {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }),
         index > 0 {
       contacts.remove(at: index)
+    }
+  }
+  func updateBottomSheetItems() {
+    contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
+      var copy = item
+      let type = ContactModel.ContactType.from(iconName: item.icon)
+      
+      if contacts.contains(where: { $0.type == type }) {
+        copy.state = .disable
+      } else {
+        copy.state = .unselected
+      }
+      
+      return copy
     }
   }
 }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -170,8 +170,6 @@ final class CreateBasicInfoViewModel {
       return ""
     }
   }
-  var contactInfoText: String = ""
-  var showAdditionalContactError: Bool = false
   
   // temp
   var smokingStatus: String = ""
@@ -181,7 +179,6 @@ final class CreateBasicInfoViewModel {
   var customJobText: String = ""
   var isCustomJobSelected: Bool = false
   var selectedSNSContactType: ContactModel.ContactType? = nil
-  var selectedContactForIconChange: ContactModel? = nil
   var prevSelectedContact: ContactModel? = nil
   var isContactTypeChangeSheetPresented: Bool = false
   var selectedItem: PhotosPickerItem? = nil
@@ -354,29 +351,6 @@ final class CreateBasicInfoViewModel {
     if let index = contacts.firstIndex(where: { $0.id == contact.id }) {
       contacts[index] = ContactModel(type: newType, value: contact.value)
     }
-  }
-  
-  func saveSelectedSNSItem() {
-    if let selectedType = selectedSNSContactType {
-      if let contact = selectedContactForIconChange {
-        // 아이콘 변경 시 처리
-        updateContactType(for: contact, newType: selectedType)
-      } else {
-        // 새 연락처 추가 시 처리
-        contacts.append(ContactModel(type: selectedType, value: ""))
-      }
-    }
-    
-    // 상태 초기화
-    isSNSSheetPresented = false
-    isContactTypeChangeSheetPresented = false
-    selectedSNSContactType = nil
-    selectedContactForIconChange = nil
-  }
-  
-  func removeContact(at index: Int) {
-    guard contacts.indices.contains(index), index != 0 else { return }
-    contacts.remove(at: index)
   }
   
   func loadImage() async {


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-911](https://yapp25app3.atlassian.net/browse/PC-911)

## 👷🏼‍♂️ 변경 사항
- `PCBottomSheet` 구조 개선
  - `PCBottomSheetItemRepresentable` 프로토콜을 정의했습니다.
    - `id`, `text`, `state`, `render()`를 포함합니다.
    - 위 프로토콜을 채택하는 `BottomSheetIconItem`과 `BottomSheetTextItem` 배열을 `PCBottomSheet` 인스턴스에 **Only 전달**만 하면 **피그마 바텀시트 디자인 요구사항에 맞는 모든 바텀시트 UI를 구현**할 수 있습니다.
    - 기존 바텀시트의 화면전환 시 `.sheet()` 모디파이어를 사용하지 않는 구조를 개선하여 애니메이션과 함께 화면이 전환됩니다.
- PCBottomSheet를 개선한 이유
  - 기존 PCBottomSheet는 이스케이핑 클로저를 통해서 내부 컨텐츠를 구현하여 전달하는 구조였습니다.
  - 이 경우에 내부 `PCBottomSheet`에서 편집 중 상태관리가 어려웠고, 이를 구현하기 위해서는 바텀시트가 많은 `EditProfileView`와 `CreateBasicInfoView`에서 더욱 하드 코딩을 통한 1000줄 이상이 예상되어 `PCBottomSheet` 구조를 개선했습니다.

- ContactModel 프로퍼티 추가
  - 프로필 변경/생성의 ViewModel 내부 Contact와의 매핑을 위한 Sugar를 추가했습니다. (다른 영향은 미치지 않습니다.)

### PCBottomSheet 예시
| BottomSheetIconItem | BottomSheetTextItem |
| :--: | :--: |
| ![IconItem](https://github.com/user-attachments/assets/f17830b3-c022-4152-8f80-43ee97707e4c) |  ![TextItem](https://github.com/user-attachments/assets/5d5f2494-205e-4fa3-ae1e-1bb74d891707) |

### BottomSheetTextItem 사용 예시 
```swift
    .sheet(isPresented: $viewModel.isLocationSheetPresented) {
      PCBottomSheet<BottomSheetTextItem>(
        isButtonEnabled: .constant(true), // 바텀시트 버튼의 Enable 여부
        items: $viewModel.locationItems, // 바텀시트 내부 RowItem의 모델
        titleText: "활동 지역",
        subtitleText: "주로 활동하는 지역을 선택해주세요.",
        buttonText: "적용하기",
        buttonAction: { viewModel.handleAction(.saveLocation) }, // 바텀시트 버튼의 액션
        onTapRowItem: { viewModel.tapRowItem($0) } // 바텀시트 RowItem 탭 시 액션
      )
      .presentationDetents([.height(602)])
    }
```

### BottomSheetIconItem 사용 예시
```swift
    .sheet(isPresented: $viewModel.isSNSSheetPresented) {
      PCBottomSheet<BottomSheetIconItem>(
        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)), // 바텀시트 버튼의 Enable 여부
        items: $viewModel.contactBottomSheetItems,  // 바텀시트 내부 RowItem의 모델
        titleText: "연락처",
        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
        buttonText: "적용하기",
        buttonAction: { viewModel.handleAction(.saveContact) },// 바텀시트 버튼의 액션
        onTapRowItem: { viewModel.tapRowItem($0) } // 바텀시트 RowItem 탭 시 액션
      )
      .presentationDetents([.height(458)])
    }
```


## 💬 참고 사항
- 현재 Job, Location 관련 로직이 구현되어있지 않아 다음 PR에서 빠르게 처리할 예정입니다.
- 또한 Job의 경우 "기타" 탭에서 텍스트필드가 존재하여 이를 커버하기 위해서 PCBottomSheet의 변경이 조금(?) 예상됩니다.

## 📸 스크린샷(Optional)
| 연락처 추가(적용) | 연락처 변경(적용) |
| :--: | :--: |
| ![연락처 추가](https://github.com/user-attachments/assets/28bf065a-9734-4bd4-863d-b378caf85ae9) | ![연락처 변경](https://github.com/user-attachments/assets/59cd111c-3760-4fee-a5bb-264404d57167) |

| 연락처 추가(캔슬) | 연락처 변경(캔슬) |
| :--: | :--: |
| ![연락처 추가 캔슬](https://github.com/user-attachments/assets/5ab93e7a-c547-4870-b127-62372566a8cf) |  ![연락처 변경 캔슬](https://github.com/user-attachments/assets/099c7af6-dec9-4333-98d6-13740cf9df8e) |

[PC-911]: https://yapp25app3.atlassian.net/browse/PC-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ