### PR TITLE
[PC-947] Fix: 활동 지역과 직업을 각각 한 개씩 선택할 수 있다

### DIFF
--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -145,7 +145,7 @@ struct EditProfileView: View {
       )
       .presentationDetents([.height(562)])
     }
-    .sheet(isPresented: $viewModel.isSNSSheetPresented) {
+    .sheet(isPresented: $viewModel.isContactSheetPresented) {
       PCBottomSheet<BottomSheetIconItem>(
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
         items: $viewModel.contactBottomSheetItems,
@@ -153,7 +153,7 @@ struct EditProfileView: View {
         subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveContact) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapContactRowItem($0) }
       )
       .presentationDetents([.height(458)])
     }
@@ -165,7 +165,7 @@ struct EditProfileView: View {
         subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.editContact) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapContactRowItem($0) }
       )
       .presentationDetents([.height(458)])
     }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -136,12 +136,12 @@ struct EditProfileView: View {
     }
     .sheet(isPresented: $viewModel.isJobSheetPresented) {
       PCBottomSheet<BottomSheetTextItem>(
-        isButtonEnabled: .constant(true),
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isJobBottomSheetButtonEnable)),
         items: $viewModel.jobItems,
         titleText: "직업",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveJob) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapJobRowItem($0) }
       )
       .presentationDetents([.height(562)])
     }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -124,13 +124,13 @@ struct EditProfileView: View {
     .toolbar(.hidden, for: .navigationBar)
     .sheet(isPresented: $viewModel.isLocationSheetPresented) {
       PCBottomSheet<BottomSheetTextItem>(
-        isButtonEnabled: .constant(true),
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isLocationBottomSheetButtonEnable)),
         items: $viewModel.locationItems,
         titleText: "활동 지역",
         subtitleText: "주로 활동하는 지역을 선택해주세요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveLocation) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapLocationRowItem($0) }
       )
       .presentationDetents([.height(602)])
     }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -231,7 +231,7 @@ final class EditProfileViewModel {
   var canAddMoreContact: Bool {
     contacts.count < Constant.contactModelCount
   }
-  var isSNSSheetPresented: Bool = false
+  var isContactSheetPresented: Bool = false
   var isProfileImageSheetPresented: Bool = false
   var showToast: Bool = false
   
@@ -256,12 +256,12 @@ final class EditProfileViewModel {
       isJobSheetPresented = true
       updateJobBottomSheetItems()
     case .tapAddContact:
-      isSNSSheetPresented = true
-      updateBottomSheetItems()
+      isContactSheetPresented = true
+      updateContactBottomSheetItems()
     case .tapChangeContact(let prevContact):
       isContactTypeChangeSheetPresented = true
-      updateBottomSheetItems()
-      changeBottomSheetItem(with: prevContact)
+      updateContactBottomSheetItems()
+      changeContactBottomSheetItem(with: prevContact)
       prevSelectedContact = prevContact
     case .saveLocation:
       tapLocationBottomSheetSaveButton()
@@ -422,81 +422,19 @@ final class EditProfileViewModel {
   }
 }
 
-// MARK: ContactContainer
+// MARK: - Location
 extension EditProfileViewModel {
-  func canDeleteContactField(contact: ContactModel) -> Bool {
-    guard let index = contacts.firstIndex(where: { $0.id == contact.id }) else {
-      return false
-    }
-    return index > 0
-  }
-  
-  func removeContact(for contact: ContactModel) {
-    if let index = contacts.firstIndex(where: { $0.id == contact.id }),
-       index > 0 {
-      contacts.remove(at: index)
-    }
-  }
-
   var isLocationBottomSheetButtonEnable: Bool {
     locationItems.contains(where: { $0.state == .selected })
-  }
-  
-  var isJobBottomSheetButtonEnable: Bool {
-    jobItems.contains(where: { $0.state == .selected })
-  }
-  
-  var isContactBottomSheetButtonEnable: Bool {
-      contactBottomSheetItems.contains(where: { $0.state == .selected })
-  }
-}
-
-
-// MARK: - Mutation
-
-extension EditProfileViewModel {
-  func changeBottomSheetItem(with targetContact: ContactModel) {
-    if let contactIndex = contacts.firstIndex(where: { $0.id == targetContact.id }) {
-      let targetIcon = contacts[contactIndex].type.icon
-      
-      if let itemIndex = contactBottomSheetItems.firstIndex(where: { $0.icon == targetIcon }) {
-        contactBottomSheetItems[itemIndex].state = .selected
-      }
-    }
   }
   
   func updateLocationBottomSheetItems() {
     for index in locationItems.indices {
       locationItems[index].state = .unselected
     }
-
+    
     if let index = locationItems.firstIndex(where: { $0.text == location }) {
       locationItems[index].state = .selected
-    }
-  }
-  
-  func updateJobBottomSheetItems() {
-    for index in jobItems.indices {
-      jobItems[index].state = .unselected
-    }
-
-    if let index = jobItems.firstIndex(where: { $0.text == job }) {
-      jobItems[index].state = .selected
-    }
-  }
-  
-  func updateBottomSheetItems() {
-    contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
-      var copy = item
-      let type = ContactModel.ContactType.from(iconName: item.icon)
-      
-      if contacts.contains(where: { $0.type == type }) {
-        copy.state = .disable
-      } else {
-        copy.state = .unselected
-      }
-      
-      return copy
     }
   }
   
@@ -513,6 +451,31 @@ extension EditProfileViewModel {
     }
   }
   
+  func tapLocationBottomSheetSaveButton() {
+    if let selectedItem = locationItems.first(where: { $0.state == .selected }) {
+      location = selectedItem.text
+    }
+    
+    isLocationSheetPresented = false
+  }
+}
+
+// MARK: - Job
+extension EditProfileViewModel {
+  var isJobBottomSheetButtonEnable: Bool {
+    jobItems.contains(where: { $0.state == .selected })
+  }
+  
+  func updateJobBottomSheetItems() {
+    for index in jobItems.indices {
+      jobItems[index].state = .unselected
+    }
+    
+    if let index = jobItems.firstIndex(where: { $0.text == job }) {
+      jobItems[index].state = .selected
+    }
+  }
+  
   func tapJobRowItem(_ item: any BottomSheetItemRepresentable) {
     if let index = jobItems.firstIndex(where: { $0.id == item.id }),
        item.state == .unselected {
@@ -526,7 +489,61 @@ extension EditProfileViewModel {
     }
   }
   
-  func tapRowItem(_ item: any BottomSheetItemRepresentable) {
+  func tapJobBottomSheetSaveButton() {
+    if let selectedItem = jobItems.first(where: { $0.state == .selected }) {
+      job = selectedItem.text
+    }
+    
+    isJobSheetPresented = false
+  }
+}
+
+// MARK: - Contact
+extension EditProfileViewModel {
+  var isContactBottomSheetButtonEnable: Bool {
+    contactBottomSheetItems.contains(where: { $0.state == .selected })
+  }
+  
+  func canDeleteContactField(contact: ContactModel) -> Bool {
+    guard let index = contacts.firstIndex(where: { $0.id == contact.id }) else {
+      return false
+    }
+    return index > 0
+  }
+  
+  func removeContact(for contact: ContactModel) {
+    if let index = contacts.firstIndex(where: { $0.id == contact.id }),
+       index > 0 {
+      contacts.remove(at: index)
+    }
+  }
+  
+  func changeContactBottomSheetItem(with targetContact: ContactModel) {
+    if let contactIndex = contacts.firstIndex(where: { $0.id == targetContact.id }) {
+      let targetIcon = contacts[contactIndex].type.icon
+      
+      if let itemIndex = contactBottomSheetItems.firstIndex(where: { $0.icon == targetIcon }) {
+        contactBottomSheetItems[itemIndex].state = .selected
+      }
+    }
+  }
+  
+  func updateContactBottomSheetItems() {
+    contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
+      var copy = item
+      let type = ContactModel.ContactType.from(iconName: item.icon)
+      
+      if contacts.contains(where: { $0.type == type }) {
+        copy.state = .disable
+      } else {
+        copy.state = .unselected
+      }
+      
+      return copy
+    }
+  }
+  
+  func tapContactRowItem(_ item: any BottomSheetItemRepresentable) {
     if let index = contactBottomSheetItems.firstIndex(where: { $0.id == item.id }),
        item.state == .unselected {
       contactBottomSheetItems.enumerated().forEach { (i, item) in
@@ -550,11 +567,11 @@ extension EditProfileViewModel {
         contacts[targetIndex] = changedContact
       }
     }
-
+    
     prevSelectedContact = nil
     isContactTypeChangeSheetPresented = false
   }
-
+  
   func tapContactBottomSheetSaveButton() {
     if let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
       let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)
@@ -564,24 +581,8 @@ extension EditProfileViewModel {
         contacts.append(newContact)
       }
     }
-
-    isSNSSheetPresented = false
-  }
-
-  func tapLocationBottomSheetSaveButton() {
-    if let selectedItem = locationItems.first(where: { $0.state == .selected }) {
-      location = selectedItem.text
-    }
     
-    isLocationSheetPresented = false
-  }
-  
-  func tapJobBottomSheetSaveButton() {
-    if let selectedItem = jobItems.first(where: { $0.state == .selected }) {
-      job = selectedItem.text
-    }
-    
-    isJobSheetPresented = false
+    isContactSheetPresented = false
   }
 }
 

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -258,6 +258,7 @@ final class EditProfileViewModel {
       }
     case .tapLocation:
       isLocationSheetPresented = true
+      updateLocationBottomSheetItems()
     case .tapJob:
       isJobSheetPresented = true
     case .tapAddContact:
@@ -450,6 +451,10 @@ extension EditProfileViewModel {
       contacts.remove(at: index)
     }
   }
+
+  var isLocationBottomSheetButtonEnable: Bool {
+    locationItems.contains(where: { $0.state == .selected })
+  }
   
   var isContactBottomSheetButtonEnable: Bool {
       contactBottomSheetItems.contains(where: { $0.state == .selected })
@@ -470,6 +475,16 @@ extension EditProfileViewModel {
     }
   }
   
+  func updateLocationBottomSheetItems() {
+    for index in locationItems.indices {
+      locationItems[index].state = .unselected
+    }
+
+    if let index = locationItems.firstIndex(where: { $0.text == location }) {
+      locationItems[index].state = .selected
+    }
+  }
+  
   func updateBottomSheetItems() {
     contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
       var copy = item
@@ -482,6 +497,19 @@ extension EditProfileViewModel {
       }
       
       return copy
+    }
+  }
+  
+  func tapLocationRowItem(_ item: any BottomSheetItemRepresentable) {
+    if let index = locationItems.firstIndex(where: { $0.id == item.id }),
+       item.state == .unselected {
+      locationItems.enumerated().forEach { (i, item) in
+        if locationItems[i].state == .unselected, i == index {
+          locationItems[i].state = .selected
+        } else if locationItems[i].state == .selected {
+          locationItems[i].state = .unselected
+        }
+      }
     }
   }
   
@@ -528,7 +556,11 @@ extension EditProfileViewModel {
   }
 
   func tapLocationBottomSheetSaveButton() {
-    // TODO: location 적용 로직
+    if let selectedItem = locationItems.first(where: { $0.state == .selected }) {
+      location = selectedItem.text
+    }
+    
+    isLocationSheetPresented = false
   }
   
   func tapJobBottomSheetSaveButton() {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -193,7 +193,6 @@ final class EditProfileViewModel {
   // temp
   var smokingStatus: String = ""
   var snsActivityLevel: String = ""
-  var selectedLocation: String? = nil
   var selectedJob: String? = nil
   var customJobText: String = ""
   var isCustomJobSelected: Bool = false
@@ -228,13 +227,7 @@ final class EditProfileViewModel {
       }
     }
   }
-  var isLocationSheetPresented: Bool = false {
-    didSet {
-      if isLocationSheetPresented {
-        selectedLocation = location
-      }
-    }
-  }
+  var isLocationSheetPresented: Bool = false
   var canAddMoreContact: Bool {
     contacts.count < Constant.contactModelCount
   }
@@ -356,14 +349,6 @@ final class EditProfileViewModel {
     selectedJob = nil
     customJobText = ""
     isCustomJobSelected = false
-  }
-  
-  func saveSelectedLocation() {
-    if let selectedLocation = selectedLocation {
-      self.location = selectedLocation
-    }
-    isLocationSheetPresented = false
-    selectedLocation = nil
   }
   
   func updateContactType(for contact: ContactModel, newType: ContactModel.ContactType) {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -261,6 +261,7 @@ final class EditProfileViewModel {
       updateLocationBottomSheetItems()
     case .tapJob:
       isJobSheetPresented = true
+      updateJobBottomSheetItems()
     case .tapAddContact:
       isSNSSheetPresented = true
       updateBottomSheetItems()
@@ -456,6 +457,10 @@ extension EditProfileViewModel {
     locationItems.contains(where: { $0.state == .selected })
   }
   
+  var isJobBottomSheetButtonEnable: Bool {
+    jobItems.contains(where: { $0.state == .selected })
+  }
+  
   var isContactBottomSheetButtonEnable: Bool {
       contactBottomSheetItems.contains(where: { $0.state == .selected })
   }
@@ -485,6 +490,16 @@ extension EditProfileViewModel {
     }
   }
   
+  func updateJobBottomSheetItems() {
+    for index in jobItems.indices {
+      jobItems[index].state = .unselected
+    }
+
+    if let index = jobItems.firstIndex(where: { $0.text == job }) {
+      jobItems[index].state = .selected
+    }
+  }
+  
   func updateBottomSheetItems() {
     contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
       var copy = item
@@ -508,6 +523,19 @@ extension EditProfileViewModel {
           locationItems[i].state = .selected
         } else if locationItems[i].state == .selected {
           locationItems[i].state = .unselected
+        }
+      }
+    }
+  }
+  
+  func tapJobRowItem(_ item: any BottomSheetItemRepresentable) {
+    if let index = jobItems.firstIndex(where: { $0.id == item.id }),
+       item.state == .unselected {
+      jobItems.enumerated().forEach { (i, item) in
+        if jobItems[i].state == .unselected, i == index {
+          jobItems[i].state = .selected
+        } else if jobItems[i].state == .selected {
+          jobItems[i].state = .unselected
         }
       }
     }
@@ -564,7 +592,11 @@ extension EditProfileViewModel {
   }
   
   func tapJobBottomSheetSaveButton() {
-    // TODO: job 적용 로직
+    if let selectedItem = jobItems.first(where: { $0.state == .selected }) {
+      job = selectedItem.text
+    }
+    
+    isJobSheetPresented = false
   }
 }
 

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -155,13 +155,13 @@ struct CreateBasicInfoView: View {
     }
     .sheet(isPresented: $viewModel.isLocationSheetPresented) {
       PCBottomSheet<BottomSheetTextItem>(
-        isButtonEnabled: .constant(true),
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isLocationBottomSheetButtonEnable)),
         items: $viewModel.locationItems,
         titleText: "활동 지역",
         subtitleText: "주로 활동하는 지역을 선택해주세요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveLocation) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapLocationRowItem($0) }
       )
       .presentationDetents([.height(602)])
     }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -167,12 +167,12 @@ struct CreateBasicInfoView: View {
     }
     .sheet(isPresented: $viewModel.isJobSheetPresented) {
       PCBottomSheet<BottomSheetTextItem>(
-        isButtonEnabled: .constant(true),
+        isButtonEnabled: Binding(projectedValue: .constant(viewModel.isJobBottomSheetButtonEnable)),
         items: $viewModel.jobItems,
         titleText: "직업",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveJob) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapJobRowItem($0) }
       )
       .presentationDetents([.height(562)])
     }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -176,7 +176,7 @@ struct CreateBasicInfoView: View {
       )
       .presentationDetents([.height(562)])
     }
-    .sheet(isPresented: $viewModel.isSNSSheetPresented) {
+    .sheet(isPresented: $viewModel.isContactSheetPresented) {
       PCBottomSheet<BottomSheetIconItem>(
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
         items: $viewModel.contactBottomSheetItems,
@@ -184,7 +184,7 @@ struct CreateBasicInfoView: View {
         subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveContact) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapContactRowItem($0) }
       )
       .presentationDetents([.height(458)])
     }
@@ -196,7 +196,7 @@ struct CreateBasicInfoView: View {
         subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.editContact) },
-        onTapRowItem: { viewModel.tapRowItem($0) }
+        onTapRowItem: { viewModel.tapContactRowItem($0) }
       )
       .presentationDetents([.height(458)])
     }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -239,6 +239,7 @@ final class CreateBasicInfoViewModel {
       }
     case .tapLocation:
       isLocationSheetPresented = true
+      updateLocationBottomSheetItems()
     case .tapJob:
       isJobSheetPresented = true
     case .tapAddContact:
@@ -394,6 +395,10 @@ extension CreateBasicInfoViewModel {
     }
   }
   
+  var isLocationBottomSheetButtonEnable: Bool {
+    locationItems.contains(where: { $0.state == .selected })
+  }
+  
   var isContactBottomSheetButtonEnable: Bool {
       contactBottomSheetItems.contains(where: { $0.state == .selected })
   }
@@ -411,6 +416,16 @@ extension CreateBasicInfoViewModel {
     }
   }
   
+  func updateLocationBottomSheetItems() {
+    for index in locationItems.indices {
+      locationItems[index].state = .unselected
+    }
+
+    if let index = locationItems.firstIndex(where: { $0.text == location }) {
+      locationItems[index].state = .selected
+    }
+  }
+  
   func updateBottomSheetItems() {
     contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
       var copy = item
@@ -423,6 +438,19 @@ extension CreateBasicInfoViewModel {
       }
       
       return copy
+    }
+  }
+  
+  func tapLocationRowItem(_ item: any BottomSheetItemRepresentable) {
+    if let index = locationItems.firstIndex(where: { $0.id == item.id }),
+       item.state == .unselected {
+      locationItems.enumerated().forEach { (i, item) in
+        if locationItems[i].state == .unselected, i == index {
+          locationItems[i].state = .selected
+        } else if locationItems[i].state == .selected {
+          locationItems[i].state = .unselected
+        }
+      }
     }
   }
   
@@ -469,9 +497,11 @@ extension CreateBasicInfoViewModel {
   }
   
   func tapLocationBottomSheetSaveButton() {
-    // TODO: location 적용 로직
+    if let selectedItem = locationItems.first(where: { $0.state == .selected }) {
+      location = selectedItem.text
+    }
     
-    isLocationSheetPresented = true
+    isLocationSheetPresented = false
   }
   
   func tapJobBottomSheetSaveButton() {

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -212,7 +212,7 @@ final class CreateBasicInfoViewModel {
   var canAddMoreContact: Bool {
     contacts.count < Constant.contactModelCount
   }
-  var isSNSSheetPresented: Bool = false
+  var isContactSheetPresented: Bool = false
   var isProfileImageSheetPresented: Bool = false
   var showToast: Bool = false
   
@@ -237,12 +237,12 @@ final class CreateBasicInfoViewModel {
       isJobSheetPresented = true
       updateJobBottomSheetItems()
     case .tapAddContact:
-      isSNSSheetPresented = true
-      updateBottomSheetItems()
+      isContactSheetPresented = true
+      updateContactBottomSheetItems()
     case .tapChangeContact(let prevContact):
       isContactTypeChangeSheetPresented = true
-      updateBottomSheetItems()
-      changeBottomSheetItem(with: prevContact)
+      updateContactBottomSheetItems()
+      changeContactBottomSheetItem(with: prevContact)
       prevSelectedContact = prevContact
     case .saveLocation:
       tapLocationBottomSheetSaveButton()
@@ -359,79 +359,19 @@ final class CreateBasicInfoViewModel {
   }
 }
 
-// MARK: ContactContainer
+// MARK: - Location
 extension CreateBasicInfoViewModel {
-  func canDeleteContactField(contact: ContactModel) -> Bool {
-    guard let index = contacts.firstIndex(where: { $0.id == contact.id }) else {
-      return false
-    }
-    return index > 0
-  }
-  
-  func removeContact(for contact: ContactModel) {
-    if let index = contacts.firstIndex(where: { $0.id == contact.id }),
-        index > 0 {
-      contacts.remove(at: index)
-    }
-  }
-  
   var isLocationBottomSheetButtonEnable: Bool {
     locationItems.contains(where: { $0.state == .selected })
-  }
-  
-  var isJobBottomSheetButtonEnable: Bool {
-    jobItems.contains(where: { $0.state == .selected })
-  }
-  
-  var isContactBottomSheetButtonEnable: Bool {
-      contactBottomSheetItems.contains(where: { $0.state == .selected })
-  }
-}
-
-// MARK: - Mutation
-
-extension CreateBasicInfoViewModel {
-  func changeBottomSheetItem(with targetContact: ContactModel) {
-    if let contactIndex = contacts.firstIndex(where: { $0.id == targetContact.id }) {
-      let targetIcon = contacts[contactIndex].type.icon
-      if let itemIndex = contactBottomSheetItems.firstIndex(where: { $0.icon == targetIcon }) {
-        contactBottomSheetItems[itemIndex].state = .selected
-      }
-    }
   }
   
   func updateLocationBottomSheetItems() {
     for index in locationItems.indices {
       locationItems[index].state = .unselected
     }
-
+    
     if let index = locationItems.firstIndex(where: { $0.text == location }) {
       locationItems[index].state = .selected
-    }
-  }
-  
-  func updateJobBottomSheetItems() {
-    for index in jobItems.indices {
-      jobItems[index].state = .unselected
-    }
-
-    if let index = jobItems.firstIndex(where: { $0.text == job }) {
-      jobItems[index].state = .selected
-    }
-  }
-  
-  func updateBottomSheetItems() {
-    contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
-      var copy = item
-      let type = ContactModel.ContactType.from(iconName: item.icon)
-      
-      if contacts.contains(where: { $0.type == type }) {
-        copy.state = .disable
-      } else {
-        copy.state = .unselected
-      }
-      
-      return copy
     }
   }
   
@@ -448,6 +388,31 @@ extension CreateBasicInfoViewModel {
     }
   }
   
+  func tapLocationBottomSheetSaveButton() {
+    if let selectedItem = locationItems.first(where: { $0.state == .selected }) {
+      location = selectedItem.text
+    }
+    
+    isLocationSheetPresented = false
+  }
+}
+
+// MARK: - Job
+extension CreateBasicInfoViewModel {
+  var isJobBottomSheetButtonEnable: Bool {
+    jobItems.contains(where: { $0.state == .selected })
+  }
+  
+  func updateJobBottomSheetItems() {
+    for index in jobItems.indices {
+      jobItems[index].state = .unselected
+    }
+    
+    if let index = jobItems.firstIndex(where: { $0.text == job }) {
+      jobItems[index].state = .selected
+    }
+  }
+  
   func tapJobRowItem(_ item: any BottomSheetItemRepresentable) {
     if let index = jobItems.firstIndex(where: { $0.id == item.id }),
        item.state == .unselected {
@@ -461,7 +426,60 @@ extension CreateBasicInfoViewModel {
     }
   }
   
-  func tapRowItem(_ item: any BottomSheetItemRepresentable) {
+  func tapJobBottomSheetSaveButton() {
+    if let selectedItem = jobItems.first(where: { $0.state == .selected }) {
+      job = selectedItem.text
+    }
+    
+    isJobSheetPresented = false
+  }
+}
+
+// MARK: - Contact
+extension CreateBasicInfoViewModel {
+  var isContactBottomSheetButtonEnable: Bool {
+    contactBottomSheetItems.contains(where: { $0.state == .selected })
+  }
+  
+  func canDeleteContactField(contact: ContactModel) -> Bool {
+    guard let index = contacts.firstIndex(where: { $0.id == contact.id }) else {
+      return false
+    }
+    return index > 0
+  }
+  
+  func removeContact(for contact: ContactModel) {
+    if let index = contacts.firstIndex(where: { $0.id == contact.id }),
+       index > 0 {
+      contacts.remove(at: index)
+    }
+  }
+  
+  func changeContactBottomSheetItem(with targetContact: ContactModel) {
+    if let contactIndex = contacts.firstIndex(where: { $0.id == targetContact.id }) {
+      let targetIcon = contacts[contactIndex].type.icon
+      if let itemIndex = contactBottomSheetItems.firstIndex(where: { $0.icon == targetIcon }) {
+        contactBottomSheetItems[itemIndex].state = .selected
+      }
+    }
+  }
+  
+  func updateContactBottomSheetItems() {
+    contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
+      var copy = item
+      let type = ContactModel.ContactType.from(iconName: item.icon)
+      
+      if contacts.contains(where: { $0.type == type }) {
+        copy.state = .disable
+      } else {
+        copy.state = .unselected
+      }
+      
+      return copy
+    }
+  }
+  
+  func tapContactRowItem(_ item: any BottomSheetItemRepresentable) {
     if let index = contactBottomSheetItems.firstIndex(where: { $0.id == item.id }),
        item.state == .unselected {
       contactBottomSheetItems.enumerated().forEach { (i, item) in
@@ -485,11 +503,11 @@ extension CreateBasicInfoViewModel {
         contacts[targetIndex] = changedContact
       }
     }
-
+    
     prevSelectedContact = nil
     isContactTypeChangeSheetPresented = false
   }
-
+  
   func tapContactBottomSheetSaveButton() {
     if let selectedItem = contactBottomSheetItems.first(where: { $0.state == .selected }) {
       let newType = ContactModel.ContactType.from(iconName: selectedItem.icon)
@@ -499,24 +517,8 @@ extension CreateBasicInfoViewModel {
         contacts.append(newContact)
       }
     }
-
-    isSNSSheetPresented = false
-  }
-  
-  func tapLocationBottomSheetSaveButton() {
-    if let selectedItem = locationItems.first(where: { $0.state == .selected }) {
-      location = selectedItem.text
-    }
     
-    isLocationSheetPresented = false
-  }
-  
-  func tapJobBottomSheetSaveButton() {
-    if let selectedItem = jobItems.first(where: { $0.state == .selected }) {
-      job = selectedItem.text
-    }
-    
-    isJobSheetPresented = false
+    isContactSheetPresented = false
   }
 }
 

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -242,6 +242,7 @@ final class CreateBasicInfoViewModel {
       updateLocationBottomSheetItems()
     case .tapJob:
       isJobSheetPresented = true
+      updateJobBottomSheetItems()
     case .tapAddContact:
       isSNSSheetPresented = true
       updateBottomSheetItems()
@@ -399,6 +400,10 @@ extension CreateBasicInfoViewModel {
     locationItems.contains(where: { $0.state == .selected })
   }
   
+  var isJobBottomSheetButtonEnable: Bool {
+    jobItems.contains(where: { $0.state == .selected })
+  }
+  
   var isContactBottomSheetButtonEnable: Bool {
       contactBottomSheetItems.contains(where: { $0.state == .selected })
   }
@@ -426,6 +431,16 @@ extension CreateBasicInfoViewModel {
     }
   }
   
+  func updateJobBottomSheetItems() {
+    for index in jobItems.indices {
+      jobItems[index].state = .unselected
+    }
+
+    if let index = jobItems.firstIndex(where: { $0.text == job }) {
+      jobItems[index].state = .selected
+    }
+  }
+  
   func updateBottomSheetItems() {
     contactBottomSheetItems = BottomSheetIconItem.defaultContactItems.map { item in
       var copy = item
@@ -449,6 +464,19 @@ extension CreateBasicInfoViewModel {
           locationItems[i].state = .selected
         } else if locationItems[i].state == .selected {
           locationItems[i].state = .unselected
+        }
+      }
+    }
+  }
+  
+  func tapJobRowItem(_ item: any BottomSheetItemRepresentable) {
+    if let index = jobItems.firstIndex(where: { $0.id == item.id }),
+       item.state == .unselected {
+      jobItems.enumerated().forEach { (i, item) in
+        if jobItems[i].state == .unselected, i == index {
+          jobItems[i].state = .selected
+        } else if jobItems[i].state == .selected {
+          jobItems[i].state = .unselected
         }
       }
     }
@@ -505,9 +533,11 @@ extension CreateBasicInfoViewModel {
   }
   
   func tapJobBottomSheetSaveButton() {
-    // TODO: job 적용 로직
+    if let selectedItem = jobItems.first(where: { $0.state == .selected }) {
+      job = selectedItem.text
+    }
     
-    isJobSheetPresented = true
+    isJobSheetPresented = false
   }
 }
 

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -174,7 +174,6 @@ final class CreateBasicInfoViewModel {
   // temp
   var smokingStatus: String = ""
   var snsActivityLevel: String = ""
-  var selectedLocation: String? = nil
   var selectedJob: String? = nil
   var customJobText: String = ""
   var isCustomJobSelected: Bool = false
@@ -209,13 +208,7 @@ final class CreateBasicInfoViewModel {
       }
     }
   }
-  var isLocationSheetPresented: Bool = false {
-    didSet {
-      if isLocationSheetPresented {
-        selectedLocation = location
-      }
-    }
-  }
+  var isLocationSheetPresented: Bool = false
   var canAddMoreContact: Bool {
     contacts.count < Constant.contactModelCount
   }
@@ -339,20 +332,6 @@ final class CreateBasicInfoViewModel {
     selectedJob = nil
     customJobText = ""
     isCustomJobSelected = false
-  }
-  
-  func saveSelectedLocation() {
-    if let selectedLocation = selectedLocation {
-      self.location = selectedLocation
-    }
-    isLocationSheetPresented = false
-    selectedLocation = nil
-  }
-  
-  func updateContactType(for contact: ContactModel, newType: ContactModel.ContactType) {
-    if let index = contacts.firstIndex(where: { $0.id == contact.id }) {
-      contacts[index] = ContactModel(type: newType, value: contact.value)
-    }
   }
   
   func loadImage() async {


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-947](https://yapp25app3.atlassian.net/browse/PC-947)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - `Location`, `Job`의 바텀시트 ViewModel 로직 구현 및 UI 연동
  - 필요 없는 코드 및 여백 삭제
  - 일부 변수명 수정
    - `isSNSSheetPresented` -> `isContactSheetPresented`
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용
- https://github.com/Piece-iOS/Piece-iOS/pull/160 의 후속 PR입니다.
- iOS QA 사항이 많은것 같아 일단 빠르게 끝내고 다음 작업 이어해보도록 하겠습니당,,
- **Job의 경우 "기타" 탭 시 텍스트필드가 보여지는 기능 현재 미구현입니다.**

## 📸 스크린샷(Optional)
| Loctaion | Job |
| :--: | :--: |
| ![ㅁㄴㅇ](https://github.com/user-attachments/assets/3672100d-a8b7-43b8-abe9-158645a8f98d) |  ![ㅁㄴㅇ2](https://github.com/user-attachments/assets/302941e3-c62b-4d91-b94e-5217a666e137) |

[PC-947]: https://yapp25app3.atlassian.net/browse/PC-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ