### PR TITLE
[PC-952] Fix: EditProfile 화면 무한 API 호출 문제 해결

### DIFF
--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -169,6 +169,9 @@ struct EditProfileView: View {
       )
       .presentationDetents([.height(458)])
     }
+    .onAppear {
+      viewModel.handleAction(.onAppear)
+    }
   }
   
   private var navigationBar: some View {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -17,6 +17,7 @@ import PCFoundationExtension
 @Observable
 final class EditProfileViewModel {
   enum Action {
+    case onAppear
     case tapConfirmButton
     case tapVaildNickName
     case selectCamera
@@ -42,12 +43,6 @@ final class EditProfileViewModel {
     self.checkNicknameUseCase = checkNicknameUseCase
     self.uploadProfileImageUseCase = uploadProfileImageUseCase
     self.jobItems = Jobs.all.map { BottomSheetTextItem(text: $0) }
-    
-    Task {
-      await getBasicProfile()
-    }
-    
-    setupJobItemsWithEtc()
   }
   
   private let updateProfileBasicUseCase: UpdateProfileBasicUseCase
@@ -222,6 +217,12 @@ final class EditProfileViewModel {
   
   func handleAction(_ action: Action) {
     switch action {
+    case .onAppear:
+      Task {
+        await getBasicProfile()
+      }
+      
+      setupJobItemsWithEtc()
     case .tapConfirmButton:
       Task {
         await handleTapConfirmButton()


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-952](https://yapp25app3.atlassian.net/browse/PC-952)

## 👷🏼‍♂️ 변경 사항
### 작업 내용
  - `setupJobItemsWithEtc()` 호출 시점을 `init`에서 `onAppear`로 이동
  - `EditProfileViewModel` `Action`에 `.onAppear` 추가
  - Binding 사용으로 인한 ViewModel 무한 init 문제 해결
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

### 원인 분석
- 기존 `setupJobItemsWithEtc()` 함수에서 `Binding`을 사용하여 `etcText`와 `BottomSheetTextItem`을 연결하고 있었습니다.
- `Binding`이 SwiftUI의 상태 관리 시스템과 직접적으로 연결되어 있어 ViewModel의 생명주기에 영향을 미치는 것으로 보였습니다.
- 이로 인해 ViewModel이 재생성될 때마다 `init`에서 `setupJobItemsWithEtc()`가 호출되고, 다시 ViewModel이 재생성되는 무한 루프 발생했습니다.

### 해결 방법
- `setupJobItemsWithEtc()` 호출을 `init`에서 `onAppear`로 이동했습니다.
- ViewModel의 초기화 시점과 상태 업데이트 시점을 분리하여 무한 루프 방지했습니다.
- 다만 자세한 원인을 모르겠습니다,, `init` 시점에 `etcText`가 변경되고 View가 업데이트 되면 @State인 ViewModel이 재생성되는 것의 무한 반복이었는데, `init` 시점이 아닐때는 `etcText`가 변경되어도 ViewModel이 재생성되는 일이 없습니다. 현재 해결방법은 임시방편입니다.

## 📸 스크린샷(Optional)
### 관련 로직 수정 전
https://github.com/user-attachments/assets/d6b9b206-b154-466e-9b93-0afe8f3fad24

### 관련 로직 수정 후
https://github.com/user-attachments/assets/deef3ccb-c3ad-4aba-8348-3514f7d523f7

[PC-952]: https://yapp25app3.atlassian.net/browse/PC-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ