### PR TITLE
[PC-932] Feat: 구글 간편 로그인 추가 및 회원 탈퇴 로직 개선

### DIFF
--- a/Data/LocalStorage/Sources/UserDefaults/PCUserDefaultsService.swift
+++ b/Data/LocalStorage/Sources/UserDefaults/PCUserDefaultsService.swift
@@ -92,12 +92,21 @@ public extension PCUserDefaultsService {
     self.didSeeOnboarding = didSeeOnboarding
   }
   
-  func setSocialLoginType(_ type: String) {
-    self.socialLoginType = type
+  func setSocialLoginType(_ type: SocialLoginType) {
+    self.socialLoginType = type.rawValue
   }
   
-  func getSocialLoginType() -> String {
-    socialLoginType
+  func getSocialLoginType() -> SocialLoginType? {
+    switch socialLoginType {
+    case "apple":
+      return .apple
+    case "kakao":
+      return .kakao
+    case "google":
+      return .google
+    default:
+      return nil
+    }
   }
   
   /// 첫 실행 여부 확인

--- a/Data/PCNetwork/Sources/Endpoint/UserEndpoint.swift
+++ b/Data/PCNetwork/Sources/Endpoint/UserEndpoint.swift
@@ -8,6 +8,7 @@
 import Alamofire
 import DTO
 import LocalStorage
+import Entities
 
 public enum UserEndpoint: TargetType {
   case withdrawWithPiece(WithdrawRequestDTO)
@@ -24,7 +25,10 @@ public enum UserEndpoint: TargetType {
   
   public var path: String {
     switch self {
-    case .withdrawWithPiece: "api/users"
+    case .withdrawWithPiece(let dto):
+      dto.providerName == SocialLoginType.apple.rawValue
+      ? "api/users/oauth"
+      : "api/users"
     case .getUserRole: "api/users/info"
     case .userReject: "api/users/reject"
     }

--- a/Data/Repository/Sources/Login/LoginRepository.swift
+++ b/Data/Repository/Sources/Login/LoginRepository.swift
@@ -44,6 +44,12 @@ public final class LoginRepository: LoginRepositoryInterface {
     let body = VerifySMSCodeRequestDTO(phoneNumber: phoneNumber, code: code)
     let endpoint = RegisterEndpoint.verifySMSCode(body: body)
     let responseDTO: VerifySMSCodeResponseDTO = try await networkService.request(endpoint: endpoint)
+    if let accessToken = responseDTO.accessToken,
+       let refreshToken = responseDTO.refreshToken {
+      PCKeychainManager.shared.save(.accessToken, value: accessToken)
+      PCKeychainManager.shared.save(.refreshToken, value: refreshToken)
+      networkService.updateCredentials()
+    }
     return responseDTO.toDomain()
   }
   

--- a/Data/Repository/Sources/Profile/ProfileRepository.swift
+++ b/Data/Repository/Sources/Profile/ProfileRepository.swift
@@ -7,6 +7,7 @@
 
 import DTO
 import Entities
+import LocalStorage
 import Foundation
 import PCNetwork
 import RepositoryInterfaces
@@ -22,6 +23,9 @@ final class ProfileRepository: ProfileRepositoryInterface {
     let dto = profile.toDto()
     let endpoint = ProfileEndpoint.postProfile(dto)
     let responseDto: PostProfileResponseDTO = try await networkService.request(endpoint: endpoint)
+    PCKeychainManager.shared.save(.accessToken, value: responseDto.accessToken)
+    PCKeychainManager.shared.save(.refreshToken, value: responseDto.refreshToken)
+    networkService.updateCredentials()
     
     return responseDto.toDomain()
   }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -169,6 +169,9 @@ struct EditProfileView: View {
       )
       .presentationDetents([.height(458)])
     }
+    .onAppear {
+      viewModel.handleAction(.onAppear)
+    }
   }
   
   private var navigationBar: some View {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -17,6 +17,7 @@ import PCFoundationExtension
 @Observable
 final class EditProfileViewModel {
   enum Action {
+    case onAppear
     case tapConfirmButton
     case tapVaildNickName
     case selectCamera
@@ -42,12 +43,6 @@ final class EditProfileViewModel {
     self.checkNicknameUseCase = checkNicknameUseCase
     self.uploadProfileImageUseCase = uploadProfileImageUseCase
     self.jobItems = Jobs.all.map { BottomSheetTextItem(text: $0) }
-    
-    Task {
-      await getBasicProfile()
-    }
-    
-    setupJobItemsWithEtc()
   }
   
   private let updateProfileBasicUseCase: UpdateProfileBasicUseCase
@@ -222,6 +217,12 @@ final class EditProfileViewModel {
   
   func handleAction(_ action: Action) {
     switch action {
+    case .onAppear:
+      Task {
+        await getBasicProfile()
+      }
+      
+      setupJobItemsWithEtc()
     case .tapConfirmButton:
       Task {
         await handleTapConfirmButton()

--- a/Presentation/Feature/Login/Project.swift
+++ b/Presentation/Feature/Login/Project.swift
@@ -17,5 +17,6 @@ let project = Project.staticLibrary(
     .presentation(target: .Router),
     .externalDependency(dependency: .KakaoSDKAuth),
     .externalDependency(dependency: .KakaoSDKUser),
+    .externalDependency(dependency: .GoogleSignIn),
   ]
 )

--- a/Presentation/Feature/Login/Sources/Login/LoginView.swift
+++ b/Presentation/Feature/Login/Sources/Login/LoginView.swift
@@ -51,7 +51,7 @@ struct LoginView: View {
         VStack(spacing: 10) {
           appleLoginButton
           kakaoLoginButton
-          //googleLoginButton
+          googleLoginButton
         }
         .padding(.horizontal, 20)
       }

--- a/Presentation/Feature/Login/Sources/Login/LoginViewModel.swift
+++ b/Presentation/Feature/Login/Sources/Login/LoginViewModel.swift
@@ -98,7 +98,8 @@ final class LoginViewModel: NSObject {
       do {
         let socialLoginResponse = try await socialLoginUseCase.execute(providerName: .kakao, token: token)
         print("Social login success: \(socialLoginResponse)")
-        PCUserDefaultsService.shared.setSocialLoginType("kakao")
+        let socialLoginType = SocialLoginType.kakao
+        PCUserDefaultsService.shared.setSocialLoginType(socialLoginType)
         setRoute(userRole: socialLoginResponse.role)
       } catch {
         print("Social login failed: \(error.localizedDescription)")
@@ -130,7 +131,8 @@ final class LoginViewModel: NSObject {
     do {
       let socialLoginResponse = try await socialLoginUseCase.execute(providerName: .google, token: idToken)
       print("Google Login Success: \(socialLoginResponse)")
-      PCUserDefaultsService.shared.setSocialLoginType("google")
+      let socialLoginType = SocialLoginType.google
+      PCUserDefaultsService.shared.setSocialLoginType(socialLoginType)
       setRoute(userRole: socialLoginResponse.role)
     } catch {
       print("Social login failed: \(error.localizedDescription)")
@@ -163,7 +165,8 @@ extension LoginViewModel: ASAuthorizationControllerDelegate, ASAuthorizationCont
       do {
         let socialLoginResponse = try await socialLoginUseCase.execute(providerName: .apple, token: authorizationCode)
         print("Apple Login Success: \(socialLoginResponse)")
-        PCUserDefaultsService.shared.setSocialLoginType("apple")
+        let socialLoginType = SocialLoginType.apple
+        PCUserDefaultsService.shared.setSocialLoginType(socialLoginType)
         setRoute(userRole: socialLoginResponse.role)
       } catch {
         print("Apple Login Error: \(error.localizedDescription)")

--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
@@ -104,12 +104,6 @@ final class VerifingContactViewModel {
     do {
       print(phoneNumber, verificationCode)
       let response = try await verifySMSCodeUseCase.execute(phoneNumber: phoneNumber, code: verificationCode)
-      if let accessToken = response.accessToken {
-        PCKeychainManager.shared.save(.accessToken, value: accessToken)
-      }
-      if let refreshToken = response.refreshToken {
-        PCKeychainManager.shared.save(.refreshToken, value: refreshToken)
-      }
       if response.isPhoneNumberDuplicated {
         if let oauthProviderName = response.oauthProvider {
           self.oauthProviderName = oauthProviderName.description

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
@@ -42,20 +42,23 @@ final class WithdrawConfirmViewModel: NSObject {
   }
   
   private func handleConfirmWithdraw() async {
-    let socialLoginType = PCUserDefaultsService.shared.getSocialLoginType()
+    guard let socialLoginType = PCUserDefaultsService.shared.getSocialLoginType() else {
+      print("Unsupported login type")
+      return
+    }
+    let providerName = socialLoginType.rawValue
+    
     switch socialLoginType {
-    case "apple":
-      await revokeAppleIDCredential()
-    case "kakao":
-      await revokeKakao()
-    case "google":
-      await revokeGoogle()
-    default:
-      print("Unsupported login type: \(socialLoginType)")
+    case .apple:
+      await revokeAppleIDCredential(with: providerName)
+    case .kakao:
+      await revokeKakao(with: providerName)
+    case .google:
+      await revokeGoogle(with: providerName)
     }
   }
   
-  private func revokeKakao() async {
+  private func revokeKakao(with providerName: String) async {
     print("🔍 Kakao 탈퇴 진행")
     
     await withCheckedContinuation { continuation in
@@ -72,7 +75,7 @@ final class WithdrawConfirmViewModel: NSObject {
     do {
       do {
         _ = try await deleteUserAccountUseCase.execute(
-          providerName: "kakao",
+          providerName: providerName,
           oauthCredential: "",
           reason: withdrawReason
         )
@@ -95,7 +98,7 @@ final class WithdrawConfirmViewModel: NSObject {
     }
   }
   
-  private func revokeAppleIDCredential() async {
+  private func revokeAppleIDCredential(with providerName: String) async {
     print("🔍 Apple 탈퇴 진행")
     
     do {
@@ -103,7 +106,7 @@ final class WithdrawConfirmViewModel: NSObject {
       print("✅ Apple authorization code : \(appleIDProvider.authorizationCode)")
       do {
         _ = try await deleteUserAccountUseCase.execute(
-          providerName: "apple",
+          providerName: providerName,
           oauthCredential: appleIDProvider.authorizationCode,
           reason: withdrawReason
         )
@@ -124,12 +127,12 @@ final class WithdrawConfirmViewModel: NSObject {
     }
   }
   
-  private func revokeGoogle() async {
+  private func revokeGoogle(with providerName: String) async {
     print("🔍 Google 탈퇴 진행")
     
     do {
       _ = try await deleteUserAccountUseCase.execute(
-        providerName: "google",
+        providerName: providerName,
         oauthCredential: "",
         reason: withdrawReason
       )

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
@@ -48,6 +48,8 @@ final class WithdrawConfirmViewModel: NSObject {
       await revokeAppleIDCredential()
     case "kakao":
       await revokeKakao()
+    case "google":
+      await revokeGoogle()
     default:
       print("Unsupported login type: \(socialLoginType)")
     }
@@ -119,6 +121,32 @@ final class WithdrawConfirmViewModel: NSObject {
       }
     } catch {
       print("\(error.localizedDescription)")
+    }
+  }
+  
+  private func revokeGoogle() async {
+    print("🔍 Google 탈퇴 진행")
+    
+    do {
+      _ = try await deleteUserAccountUseCase.execute(
+        providerName: "google",
+        oauthCredential: "",
+        reason: withdrawReason
+      )
+      print("✅ DeleteUserAccount success")
+      
+      await MainActor.run {
+        initialize()
+      }
+    } catch let error as NSError {
+      if error.localizedDescription.contains("Status Code: 200") {
+        print("✅ DeleteUserAccount 성공 (Status 200)")
+        await MainActor.run {
+          initialize()
+        }
+      } else {
+        print("\(error.localizedDescription)")
+      }
     }
   }
   

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a9ef994edf9b1ae13722f8cf61ab4778c18b641acca6e2df3de6c4bb3fb518a5",
+  "originHash" : "01febd48d9730aac6984d9f856e45de869fe8aefb4c82cd237f589b7b33cc364",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
-        "version" : "1.2024011602.0"
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "6318278e8e64d21f0fdcc69004395e4d34048aaf",
-        "version" : "11.8.1"
+        "revision" : "3663b1aa6c7a1bed67ee80fd09dc6d0f9c3bb660",
+        "version" : "11.13.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "be0881ff728eca210ccb628092af400c086abda3",
-        "version" : "11.7.0"
+        "revision" : "543071966b3fb6613a2fc5c6e7112d1e998184a7",
+        "version" : "11.13.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
-        "version" : "8.0.2"
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
-        "version" : "1.65.1"
+        "revision" : "cc0001a0cf963aa40501d9c2b181e7fc9fd8ec71",
+        "version" : "1.69.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
       "state" : {
-        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
-        "version" : "100.0.0"
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -14,6 +14,9 @@ let packageSettings = PackageSettings(
     "KakaoSDKAuth": .framework,
     "KakaoSDKCommon": .framework,
     "KakaoSDKUser": .framework,
+    "GTMAppAuth": .framework,
+    "AppAuth": .framework,
+    "GoogleSignIn": .framework,
   ],
   baseSettings: .settings()
 //      .settings(

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
@@ -36,13 +36,14 @@ extension Project {
             "kakaokompassauth",
             "kakaolink"
           ],
-          "GIDClientID": "$(GIDClientID)",
+          "GIDClientID": "$(GIDClientID).apps.googleusercontent.com",
           "CFBundleShortVersionString": AppConstants.version,
           "CFBundleVersion": AppConstants.build,
           "CFBundleDisplayName": AppConstants.bundleDisplayName,
           "CFBundleURLTypes": [
             ["CFBundleURLSchemes": ["kakao$(NATIVE_APP_KEY)"]],
-            ["CFBundleURLSchemes": ["\(AppConstants.bundleId)"]]
+            ["CFBundleURLSchemes": ["\(AppConstants.bundleId)"]],
+            ["CFBundleURLSchemes": ["com.googleusercontent.apps.$(GIDClientID)"]],
           ],
           "ITSAppUsesNonExemptEncryption": false,
         ]


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-932](https://yapp25app3.atlassian.net/browse/PC-932)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - GoogleSignIn SDK 의존성 추가를 위한 Project 파일 수정
  - 기존 구글 간편로그인 UI 주석 해제
  - 구글 간편로그인 로직 구현
  - 구글 로그인한 경우 탈퇴 로직 구현

## 추가) AccessToken 키체인 저장 및 OAuthAuthentication 갱신 관련 문제 해결
### 배경
앱에서 기존 AccessToken을 저장하는 부분은 총 아래 3가지가 존재해야합니다.
`1. 소셜로그인 완료 시(NONE)`
`2. 전화번호 인증 완료 시(REGISTER) `
`3. 프로필생성 완료 시(심사이전) (PENDING) `

- 하지만 이전 1,2번에서만 토큰을 키체인에 저장하고 있었으며, 3번에는 키체인에 저장하는 로직이 없었습니다.
- 또한 이전 2,3 번에서는 `키체인 저장`과 별도로, request 헤더에 bearer 토큰을 추가하기 위한 `OAuthAuthenticator` 객체에 토큰을 업데이트하는 로직이 존재하지 않았습니다.
- 이로 인해 회원가입 및 프로필 생성 이후 홈 화면 진입 시 request 헤더에 전달되는 토큰의 상태는 `PENDING` 상태가 아닌 `NONE` 상태로 추가가 되었으며, 키체인에는 `REGISTER` 상태로 저장이 되고 있었습니다.
- 따라서, 가입 직후 바로 회원탈퇴 API 호출 시 `NONE` 상태의 토큰이 회원탈퇴 API 헤더에 추가되어 아래와 같은 `403 에러`가 발생했습니다.
(`NONE`의 경우 접근권한이 없기 때문에 deny됨, 정상적인 경우 회원가입 직후 token 복호화 시 role은 "3. `PENDING`" 이어야함)
```swift
🛰 Body: {
  "reason" : "잠깐 쉬고 싶어요",
  "providerName" : "google",
  "oauthCredential" : ""
}
🛰 NETWORK Response LOG
접근이 거부되었습니다
🛰 URL: https://dev-api.puzzly.site/api/users/oauth
🛰 Result: failure(Alamofire.AFError.responseValidationFailed(reason: Alamofire.AFError.ResponseValidationFailureReason.unacceptableStatusCode(code: 403)))
🛰 StatusCode: 403
🛰 Data: {
  "message" : "접근 권한이 없습니다.",
  "code" : "ACCESS_DENIED"
}
```
### 문제 해결
따라서 1,2,3 세 가지의 `AccessToken` `키체인 저장` 및 `OAuthAuthenticator` 갱신을 정확하게 수행하도록, 
위 문제를 아래 커밋에서 해결하였습니다.
- [(PC-932) Fix: 전화번호 인증 후 accessToken 갱신 누락 수정](https://github.com/Piece-iOS/Piece-iOS/pull/165/commits/1b4d035e60f6015c5a2b207bd1c111637101e8bb)
- [(PC-932) Fix: 프로필 생성 후 accessToken 저장 및 갱신 누락 수정](https://github.com/Piece-iOS/Piece-iOS/pull/165/commits/0aaf4c561b64b53a2d7344d68bce505daf80a4c0)


## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-932]: https://yapp25app3.atlassian.net/browse/PC-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ