### PR TITLE
[PC-979] 프로필 화면 데이터 패치 시점 변경

### DIFF
--- a/Presentation/Feature/Profile/Sources/ProfileView.swift
+++ b/Presentation/Feature/Profile/Sources/ProfileView.swift
@@ -37,6 +37,9 @@ struct ProfileView: View {
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .background(Color.grayscaleWhite)
+      .onAppear {
+        viewModel.handleAction(.onAppear)
+      }
     }
     .scrollIndicators(.hidden)
   }

--- a/Presentation/Feature/Profile/Sources/ProfileViewModel.swift
+++ b/Presentation/Feature/Profile/Sources/ProfileViewModel.swift
@@ -12,20 +12,26 @@ import UseCases
 @Observable
 @MainActor
 final class ProfileViewModel {
-  enum Action { }
+  enum Action {
+    case onAppear
+  }
   
   init(getProfileUseCase: GetProfileBasicUseCase) {
     self.getProfileUseCase = getProfileUseCase
-    
-    Task {
-      await fetchUserProfile()
-    }
   }
   
   private let getProfileUseCase: GetProfileBasicUseCase
   private(set) var isLoading = true
   private(set) var error: Error?
   private(set) var userProfile: UserProfile?
+  
+  func handleAction(_ action: Action) {
+    switch action {
+    case .onAppear:
+      isLoading = true
+      Task { await fetchUserProfile() }
+    }
+  }
   
   private func fetchUserProfile() async {
     do {


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-979](https://yapp25app3.atlassian.net/browse/PC-979)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 프로필 화면 데이터 패치 시점 변경
  - init -> onAppear
 
 
## 💬 참고 사항
- https://github.com/Piece-iOS/Piece-iOS/pull/166
위 PR과 이어지는 작업입니다.
- `ViewModel`에 `isLoading` 프로퍼티가 있는데, 당장 사용하고 있지는 않지만 예상되는 작업에 맞게 `isLoading`을 `true로` 초기화하는 코드를 추가했습니다.

## 📸 스크린샷(Optional)
| 프로필 수정 직후 패치 |
| :--: |
| ![Jun-04-2025 14-50-03](https://github.com/user-attachments/assets/1bfeccc1-16af-4903-8ad4-7bf5a6e6c26f) |

[PC-979]: https://yapp25app3.atlassian.net/browse/PC-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ