### PR TITLE
[PC-978] Fix: 인증완료 후 UI Disable 처리

### DIFF
--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
@@ -81,6 +81,7 @@ struct VerifingContactView: View {
             viewModel.phoneNumber = newValue.filter { $0.isNumber }
           }
           .textContentType(.telephoneNumber)
+          .disabled(viewModel.isPhoneVerificationCompleted)
           
           if viewModel.showVerificationField {
             PCTextField(
@@ -104,6 +105,7 @@ struct VerifingContactView: View {
                 }
               )
             )
+            .disabled(viewModel.isPhoneVerificationCompleted)
           }
           Spacer()
           

--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
@@ -31,7 +31,7 @@ final class VerifingContactViewModel {
   
   var showDuplicatePhoneNumberAlert: Bool = false
   private(set) var showVerificationField: Bool = false
-  private(set) var isActiveNextButton: Bool = false
+  private(set) var isPhoneVerificationCompleted: Bool = false
   private(set) var tapNextButtonFlag: Bool = false
   private(set) var recivedCertificationNumberButtonText: String = "인증번호 받기"
   private(set) var recivedCertificationNumberButtonWidth = Constants.buttonDefaultWidth
@@ -43,10 +43,14 @@ final class VerifingContactViewModel {
   var phoneNumber: String = ""
   var verificationCode: String = ""
   var isVerificationCodeValid: Bool {
-      !verificationCode.isEmpty && verificationCode.count >= 4
+    !verificationCode.isEmpty
+    && verificationCode.count >= 4
+    && !isPhoneVerificationCompleted
   }
   var isPhoneNumberValid: Bool {
-      !phoneNumber.isEmpty && (phoneNumber.count == 11 || phoneNumber.count == 10)
+    !phoneNumber.isEmpty
+    && (phoneNumber.count == 11 || phoneNumber.count == 10)
+    && !isPhoneVerificationCompleted
   }
   var phoneNumberTextfieldButtonType: RoundedButton.ButtonType {
     buttonType(for: isPhoneNumberValid)
@@ -55,10 +59,12 @@ final class VerifingContactViewModel {
     buttonType(for: isVerificationCodeValid)
   }
   var nextButtonType: RoundedButton.ButtonType {
-    buttonType(for: isActiveNextButton)
+    buttonType(for: isPhoneVerificationCompleted)
   }
   var timerText: String {
-    timeRemaining.formattedTime
+    isPhoneVerificationCompleted
+    ? ""
+    : timeRemaining.formattedTime
   }
   
   init(
@@ -118,7 +124,7 @@ final class VerifingContactViewModel {
       }
       
       await MainActor.run {
-        isActiveNextButton = true
+        isPhoneVerificationCompleted = true
         verificationFieldInfoText = "전화번호 인증을 완료했어요"
         verrificationFieldInfoTextColor = .primaryDefault
       }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-978](https://yapp25app3.atlassian.net/browse/PC-978)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 인증 완료 후 텍스트필드 및 버튼 disable 처리 및 timer 숨기기
  - 기존 isActiveNextButton보다 직관적인 isPhoneVerificationCompleted로 네이밍 변경하여 사용

 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
| ![Jun-04-2025 19-35-32](https://github.com/user-attachments/assets/463496f2-8f7a-4489-b052-8b62049b4e3a) |

[PC-978]: https://yapp25app3.atlassian.net/browse/PC-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ