### PR TITLE
[PC-980] Fix: 홈 화면에서 프로필 탭 접근 제어 로직 개선

### DIFF
--- a/Presentation/Feature/Home/Sources/HomeViewModel.swift
+++ b/Presentation/Feature/Home/Sources/HomeViewModel.swift
@@ -69,13 +69,6 @@ final class HomeViewModel {
     self.putSettingsMatchNotificationUseCase = putSettingsMatchNotificationUseCase
     self.putSettingsBlockAcquaintanceUseCase = putSettingsBlockAcquaintanceUseCase
     self.patchLogoutUseCase = patchLogoutUseCase
-    
-    let userRole = PCUserDefaultsService.shared.getUserRole()
-    if userRole == .USER {
-      isProfileTabDisabled = false
-    } else {
-      isProfileTabDisabled = true
-    }
   }
   
   // profile
@@ -104,5 +97,7 @@ final class HomeViewModel {
   
   // MARK: - State
   var selectedTab: Tab = .home
-  var isProfileTabDisabled: Bool
+  var isProfileTabDisabled: Bool {
+    PCUserDefaultsService.shared.getUserRole() != .USER
+  }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-932](https://yapp25app3.atlassian.net/browse/PC-932)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - HomeViewModel의 프로필 탭 접근제어 로직 개선
 
## 💬 참고 사항
- 상위뷰인 HomeView에서 init 시점에 userRole이 정해짐.
- userRole을 UserDefaults에 저장하고 있으며, 이를 통해 프로필 탭 진입 여부를 판단하기 때문에 앱 삭제후 재설치 시 api 호출이 없는 상위뷰 init 시점에 UserRole을 판단하지 못함
- 따라서 하위 뷰인 MatchingMainView에서 getUserInfoUseCase 호출 이후에 상위 뷰에서 userRole이 업데이트가 안되는 이슈가 존재했음. 
- 상위뷰에서 UserRole을 연산 프로퍼티로 UserDefaults에서 참조하여 해결


## 📸 스크린샷(Optional)
| 앱 삭제 후에도 프로필 탭 접근 가능 |
| :--: |
| ![Jun-04-2025 20-28-45](https://github.com/user-attachments/assets/f26a53d3-9ca0-4597-b38c-5f84019a10d1) |

[PC-932]: https://yapp25app3.atlassian.net/browse/PC-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ