### PR TITLE
[PC-836] Fix: 백그라운드에서도 타이머가 동작하는 기능 구현

### DIFF
--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
@@ -82,6 +82,7 @@ struct VerifingContactView: View {
             viewModel.phoneNumber = newValue.filter { $0.isNumber }
           }
           .textContentType(.telephoneNumber)
+          .keyboardType(.numberPad)
           .disabled(viewModel.isPhoneVerificationCompleted)
           
           if viewModel.showVerificationField {
@@ -106,6 +107,7 @@ struct VerifingContactView: View {
                 }
               )
             )
+            .keyboardType(.numberPad)
             .disabled(viewModel.isPhoneVerificationCompleted)
           }
           Spacer()

--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
@@ -12,11 +12,11 @@ import UseCases
 
 struct VerifingContactView: View {
   @State var viewModel: VerifingContactViewModel
-  @Environment(\.scenePhase) var scenePhase
   @FocusState private var isPhoneNumberFocused: Bool
   @FocusState private var isVerificationCodeFocused: Bool
   
   @Environment(Router.self) private var router: Router
+  @Environment(\.scenePhase) private var scenePhase
   
   init(
     sendSMSCodeUseCase: SendSMSCodeUseCase,

--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactView.swift
@@ -12,6 +12,7 @@ import UseCases
 
 struct VerifingContactView: View {
   @State var viewModel: VerifingContactViewModel
+  @Environment(\.scenePhase) var scenePhase
   @FocusState private var isPhoneNumberFocused: Bool
   @FocusState private var isVerificationCodeFocused: Bool
   
@@ -125,6 +126,9 @@ struct VerifingContactView: View {
       .padding(.horizontal, 20)
       .onChange(of: viewModel.tapNextButtonFlag) { _, newValue in
         router.setRoute(.termsAgreement)
+      }
+      .onChange(of: scenePhase) {
+        viewModel.handleAction(.updateScenePhase(scenePhase))
       }
       .ignoresSafeArea(.keyboard)
       .toolbar(.hidden, for: .navigationBar)

--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
@@ -21,6 +21,7 @@ final class VerifingContactViewModel {
   }
   
   enum Action {
+    case updateScenePhase(ScenePhase)
     case reciveCertificationNumber
     case checkCertificationNumber
     case tapNextButton
@@ -77,6 +78,8 @@ final class VerifingContactViewModel {
   
   func handleAction(_ action: Action) {
     switch action {
+    case .updateScenePhase(let scenePhase):
+      handleScenePhase(for: scenePhase)
     case .reciveCertificationNumber:
       Task { await handleReceiveCertificationNumber() }
     case .checkCertificationNumber:
@@ -135,6 +138,17 @@ final class VerifingContactViewModel {
     }
   }
   
+  private func handleScenePhase(for scenePhase: ScenePhase) {
+    switch scenePhase {
+    case .background:
+      pauseTimerIfNeeded()
+    case .active:
+      resumeTimerIfNeeded()
+    default:
+      break
+    }
+  }
+  
   private func startTimer() {
     timeRemaining = Constants.initialTime
     stopTimer()
@@ -155,6 +169,10 @@ final class VerifingContactViewModel {
   private func stopTimer() {
     timer?.invalidate()
     timer = nil
+  private func pauseTimerIfNeeded() {
+  }
+  private func resumeTimerIfNeeded() {
+  }
   }
   
   deinit {

--- a/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
+++ b/Presentation/Feature/Login/Sources/VerifingContact/VerifingContactViewModel.swift
@@ -42,6 +42,7 @@ final class VerifingContactViewModel {
   private var timer: Timer?
   private var timeRemaining: TimeInterval = Constants.initialTime
   private var isTimerRunning: Bool = false // 타이머 실행 상태 추적
+  private var backgroundTime: Date?
   var phoneNumber: String = ""
   var verificationCode: String = ""
   var isVerificationCodeValid: Bool {
@@ -173,8 +174,25 @@ final class VerifingContactViewModel {
   }
   
   private func pauseTimerIfNeeded() {
+    if isTimerRunning {
+      stopTimer()
+      backgroundTime = Date()
+    }
   }
+  
   private func resumeTimerIfNeeded() {
+    if !isTimerRunning, let backgroundTime {
+      let timeInBackground = Date().timeIntervalSince(backgroundTime)
+      timeRemaining -= timeInBackground
+      
+      if timeRemaining > 0 {
+        startTimer()
+      } else {
+        handleTimeExpired()
+      }
+      
+      self.backgroundTime = nil
+    }
   }
   
   private func handleTimeExpired() {

--- a/Utility/PCFoundationExtension/Sources/Double+Extension.swift
+++ b/Utility/PCFoundationExtension/Sources/Double+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Double+Extension.swift
+//  PCFoundationExtension
+//
+//  Created by 홍승완 on 6/7/25.
+//
+
+import Foundation
+
+public extension Double {
+  var formattedTime: String {
+    let minutes = Int(self) / 60
+    let seconds = Int(self) % 60
+    return String(format: "%02d:%02d", minutes, seconds)
+  }
+}


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-836](https://yapp25app3.atlassian.net/browse/PC-836)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 백그라운드에서 타이머가 동작하는것처럼 `남은시간을 보정`하는 로직 구현
  - 남은 시간 관련 변수 -> `timeRemaining`

### 타이머 백그라운드/포어그라운드 처리 추가
- `ScenePhase`를 통한 `앱 생명주기 감지`
- **백그라운드에서 타이머 일시정지**
- **포어그라운드로 돌아올 때 백그라운드 시간만큼 타이머 시간 차감**

### 추가된 코드
```swift
//  VerifingContactViewModel.swift
final class VerifingContactViewModel {
  ...

  private var timeRemaining: TimeInterval = Constants.initialTime
  private var isTimerRunning: Bool = false // 타이머 실행 상태 추적
  private var backgroundTime: Date?

  ...

  private func handleScenePhase(for scenePhase: ScenePhase) {
    switch scenePhase {
    case .background:
      pauseTimerIfNeeded()
    case .active:
      resumeTimerIfNeeded()
    default:
      break
    }
  }

  ...

  private func pauseTimerIfNeeded() {
    // 타이머가 실행 중일 때만 처리
    if isTimerRunning {
      stopTimer()
      backgroundTime = Date()
    }
  }
  
  private func resumeTimerIfNeeded() {
    // 타이머가 실행 중이었을 때만 처리
    if !isTimerRunning, let backgroundTime {
      // 백그라운드에서 지난 시간 계산
      let timeInBackground = Date().timeIntervalSince(backgroundTime)
      // 남은 시간에서 백그라운드 시간 차감
      timeRemaining -= timeInBackground
      
      // 시간이 남아있다면 타이머 재시작
      if timeRemaining > 0 {
        startTimer()
      } else {
        // 시간 초과 처리
        handleTimeExpired()
      }
      
      self.backgroundTime = nil
    }

  ...

  }
```
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 백그라운드 타이머 남은 시간 보정 |
| :--: |
| ![Jun-07-2025 15-22-22](https://github.com/user-attachments/assets/d5d7694b-0bec-47b3-a3b7-b3c58e7f0dd2) |

[PC-836]: https://yapp25app3.atlassian.net/browse/PC-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ