### PR TITLE
[PC-982] 프로필 관련 화면 닉네임 상태 처리 개선

### DIFF
--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -290,8 +290,8 @@ struct EditProfileView: View {
     .onSubmit {
       focusField = "description"
     }
-    .onChange(of: viewModel.nickname) { _, _ in
-      viewModel.handleAction(.updateEditingNicknameState)
+    .onChange(of: viewModel.nickname) { _, newValue in
+      viewModel.handleAction(.updateNickname(value: newValue))
     }
   }
   

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -31,7 +31,7 @@ final class EditProfileViewModel {
     case saveContact
     case editContact
     case updateEditingState
-    case updateEditingNicknameState
+    case updateNickname(value: String)
     case setImageFromCamera(UIImage)
     case selectPhoto(PhotosPickerItem?)
   }
@@ -247,8 +247,8 @@ final class EditProfileViewModel {
       tapContactBottomSheetEditButton()
     case .updateEditingState:
       updateEditingState()
-    case .updateEditingNicknameState:
-      updateEditingNicknameState()
+    case .updateNickname(let value):
+      handleUpdateNickname(value)
     case .setImageFromCamera(let image):
         Task { await setImageFromCamera(image) }
     case .selectPhoto(let item):
@@ -407,6 +407,11 @@ final class EditProfileViewModel {
     }
   }
 
+  private func handleUpdateNickname(_ newValue: String) {
+    nickname = newValue.replacingOccurrences(of: " ", with: "")
+    updateEditingNicknameState()
+  }
+  
   private func updateEditingNicknameState(to state: NicknameState? = nil) {
     if let state {
       nicknameState = state

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -255,19 +255,22 @@ struct CreateBasicInfoView: View {
     )
     .withButton(
       RoundedButton(
-        type: .solid,
+        type: viewModel.nicknameState.isEnableNickNameCheckButton ? .solid : .disabled,
         buttonText: "중복검사",
         width: .maxWidth,
-        action: { viewModel.handleAction(.tapVaildNickName)}
+        action: { viewModel.handleAction(.tapVaildNickName) }
       )
     )
     .infoText(
-      viewModel.nicknameInfoText,
-      color: viewModel.nicknameInfoTextColor
+      viewModel.nicknameState.infoText,
+      color: viewModel.nicknameState.infoTextColor
     )
     .textMaxLength(6)
     .onSubmit {
       focusField = "description"
+    }
+    .onChange(of: viewModel.nickname) { _, newValue in
+      viewModel.handleAction(.updateNickname(value: newValue))
     }
   }
   


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-982](https://yapp25app3.atlassian.net/browse/PC-982)

## 👷🏼‍♂️ 변경 사항
### 프로필 생성 화면에 닉네임 상태 처리 열거형 추가
  - 프로필 편집 화면과 같이 `NicknameState`를 추가하여 별도의 닉네임 관련 상태 처리 추가
  - 프로필 편집 화면과 달리 **"다음"** 버튼 탭이 가능하기 때문에 empty 상태에도 관련 에러를 추가해주었음.
### 닉네임 공백 입력 차단
 - 별도 공백 입력을 막는 로직이 없는 것을 확인하여 `"   "` 이러한 공백을 닉네임으로 중복 검사 API를 요청했을 때에도 사용 가능한 닉네임으로 true를 리턴해주었음.
 - 이를 막기위해 프로필 생성 및 편집 화면의 Action에 공백을 제거하는 로직을 추가하였음.
 
## 💬 참고 사항
**아래 PR의 후속 PR입니다.**
- https://github.com/Piece-iOS/Piece-iOS/pull/166


## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |