### PR TITLE
[PC-1012] Fix: UserInfo API 리스폰스 필드 변경 대응

### DIFF
--- a/Data/DTO/Sources/User/UserInfoResponseDTO.swift
+++ b/Data/DTO/Sources/User/UserInfoResponseDTO.swift
@@ -12,6 +12,9 @@ public struct UserInfoResponseDTO: Decodable {
   public let userId: Int
   public let role: String
   public let profileStatus: ProfileStatus?
+  public let hasRoleChanged: Bool
+  public let accessToken: String?
+  public let refreshToken: String?
 }
 
 public extension UserInfoResponseDTO {

--- a/Data/Repository/Project.swift
+++ b/Data/Repository/Project.swift
@@ -13,6 +13,7 @@ let project = Project.dynamicFramework(
   dependencies: [
     .domain(target: .RepositoryInterfaces),
     .domain(target: .Entities),
+    .data(target: .LocalStorage),
     .data(target: .DTO),
     .data(target: .PCNetwork)
   ]

--- a/Data/Repository/Sources/User/UserRepository.swift
+++ b/Data/Repository/Sources/User/UserRepository.swift
@@ -23,6 +23,24 @@ final class UserRepository: UserRepositoryInterface {
     let endpoint = UserEndpoint.getUserRole
     let response: UserInfoResponseDTO = try await networkService.request(endpoint: endpoint)
     
+    updateTokensIfRoleChanged(response: response)
+    
     return response.toDomain()
+  }
+}
+
+private extension UserRepository {
+  func updateTokensIfRoleChanged(response userInfoResponse: UserInfoResponseDTO) {
+    guard userInfoResponse.hasRoleChanged,
+          let accessToken = userInfoResponse.accessToken,
+          let refreshToken = userInfoResponse.refreshToken
+    else { return }
+    
+    saveTokens(accessToken: accessToken, refreshToken: refreshToken)
+  }
+  
+  func saveTokens(accessToken: String, refreshToken: String) {
+    PCKeychainManager.shared.save(.accessToken, value: accessToken)
+    PCKeychainManager.shared.save(.refreshToken, value: refreshToken)
   }
 }

--- a/Data/Repository/Sources/User/UserRepository.swift
+++ b/Data/Repository/Sources/User/UserRepository.swift
@@ -7,6 +7,7 @@
 
 import DTO
 import Entities
+import LocalStorage
 import PCNetwork
 import RepositoryInterfaces
 


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1012](https://yapp25app3.atlassian.net/browse/PC-1012)

## 👷🏼‍♂️ 변경 사항
### UserInfoResponseDTO 변경
```swift
public struct UserInfoResponseDTO: Decodable {
  public let userId: Int
  public let role: String
  public let profileStatus: ProfileStatus?
+ public let hasRoleChanged: Bool
+ public let accessToken: String?
+ public let refreshToken: String?
}
```
- `hasRoleChanged` -> 굳이 왜 줬는 지는 모르겠음?
- `accessToken`, `refreshToken` -> 갱신하면 됨

<br>
<br>

### UserRepository에 LocalStorage 의존성 추가
- 토큰 저장을 위한 `PCKeychainManager`에 접근하기 위함

<br>
<br>

### UserInfo API 응답 시 토큰을 변경할 필요가 있으면 갱신하는 로직 추가
```swift
final class UserRepository: UserRepositoryInterface {
  ...  
  func getUserRole() async throws -> UserInfoModel {
    let endpoint = UserEndpoint.getUserRole
    let response: UserInfoResponseDTO = try await networkService.request(endpoint: endpoint)
    
+ updateTokensIfRoleChanged(response: response)
    
    return response.toDomain()
  }
}

+ private extension UserRepository {
+   func updateTokensIfRoleChanged(response userInfoResponse: UserInfoResponseDTO) {
+     guard userInfoResponse.hasRoleChanged,
+         let accessToken = userInfoResponse.accessToken,
+         let refreshToken = userInfoResponse.refreshToken
+     else { return }
+    
+     saveTokens(accessToken: accessToken, refreshToken: refreshToken)
+   }
+   
+   func saveTokens(accessToken: String, refreshToken: String) {
+     PCKeychainManager.shared.save(.accessToken, value: accessToken)
+     PCKeychainManager.shared.save(.refreshToken, value: refreshToken)
+   }
+ }

```


## 💬 참고 사항
- `250627 20:33` 기준 아직 개발 서버에만 배포되어 있기 때문에 `운영 서버에 배포되는 시점에 머지`해야함.
- 안그러면 디코딩 에러로 `MatchingMainView`가 비어 있습니다~

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1012]: https://yapp25app3.atlassian.net/browse/PC-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ