### PR TITLE
[PC-1013] 프로필 수정 화면 알러트, 토스트 기능 구현

### DIFF
--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -115,16 +115,6 @@ struct EditProfileView: View {
         }
       }
       .ignoresSafeArea(.keyboard)
-      
-      VStack {
-        Spacer()
-        if viewModel.showToast {
-          toast
-            .padding(.bottom, 84)
-            .opacity(viewModel.showToast ? 1 : 0)
-            .animation(.easeInOut(duration: 0.5), value: viewModel.showToast)
-        }
-      }
     }
     .toolbar(.hidden, for: .navigationBar)
     .sheet(isPresented: $viewModel.isLocationSheetPresented) {
@@ -524,23 +514,6 @@ struct EditProfileView: View {
       
       EditContactContainer(viewModel: viewModel, focusField: $focusField)
     }
-  }
-  
-  private var toast: some View {
-    HStack {
-      DesignSystemAsset.Icons.notice20.swiftUIImage
-        .renderingMode(.template)
-      Text("모든 항목을 작성해 주세요")
-        .pretendard(.body_S_M)
-    }
-    .foregroundStyle(Color.grayscaleWhite)
-    .padding(.vertical, 8)
-    .padding(.horizontal, 20)
-    .background(
-      Rectangle()
-        .foregroundStyle(Color.grayscaleDark2)
-        .cornerRadius(12)
-    )
   }
   
   private var profileExitAlert: AlertView<Text> {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -177,6 +177,9 @@ struct EditProfileView: View {
     .pcAlert(isPresented: $viewModel.showProfileExitAlert) {
       profileExitAlert
     }
+    .pcAlert(isPresented: $viewModel.showImageReexaminationAlert) {
+      imageReexaminationAlert
+    }
     .onAppear {
       viewModel.handleAction(.onAppear)
     }
@@ -549,6 +552,18 @@ struct EditProfileView: View {
       secondButtonText: "이어서 작성하기",
       firstButtonAction: { viewModel.handleAction(.popBack) },
       secondButtonAction: { viewModel.handleAction(.tapCloseAlert) }
+    )
+  }
+
+  private var imageReexaminationAlert: AlertView<Text> {
+    AlertView(
+      icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
+      title: { Text("사진은 심사 통과 후 반영됩니다!") },
+      message: "안전한 커뮤니티를 위해 사진은 수정 시\n심사를 다시 진행해요. 신중하게 변경해 주세요!",
+      firstButtonText: "뒤로",
+      secondButtonText: "변경하기",
+      firstButtonAction: { viewModel.handleAction(.tapCloseAlert) },
+      secondButtonAction: { viewModel.handleAction(.tapConfirmImageReexamination) }
     )
   }
 }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -170,6 +170,12 @@ struct EditProfileView: View {
     .pcAlert(isPresented: $viewModel.showImageReexaminationAlert) {
       imageReexaminationAlert
     }
+    .overlay(alignment: .bottom) {
+      PCToast(
+        isVisible: $viewModel.showProfileEditSuccessToast,
+        text: viewModel.toastMessage
+      )
+    }
     .onAppear {
       viewModel.handleAction(.onAppear)
     }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -174,15 +174,23 @@ struct EditProfileView: View {
       )
       .presentationDetents([.height(479)])
     }
+    .pcAlert(isPresented: $viewModel.showProfileExitAlert) {
+      profileExitAlert
+    }
     .onAppear {
       viewModel.handleAction(.onAppear)
+    }
+    .onChange(of: viewModel.shouldPopBack) { _, shouldPopBack in
+      if shouldPopBack { 
+        router.pop()
+      }
     }
   }
   
   private var navigationBar: some View {
     NavigationBar(
       title: "기본 정보 수정",
-      leftButtonTap: { router.pop() },
+      leftButtonTap: { viewModel.handleAction(.tapBackButton) },
       rightButton: Button {
         viewModel.handleAction(.tapConfirmButton)
         focusField = nil
@@ -529,6 +537,18 @@ struct EditProfileView: View {
       Rectangle()
         .foregroundStyle(Color.grayscaleDark2)
         .cornerRadius(12)
+    )
+  }
+  
+  private var profileExitAlert: AlertView<Text> {
+    AlertView(
+      icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
+      title: { Text("작성 중인 프로필이 사라져요!") },
+      message: "지금 뒤로 가면 프로필이 저장되지 않습니다.\n계속 이어서 작성해 보세요.",
+      firstButtonText: "작성 중단하기",
+      secondButtonText: "이어서 작성하기",
+      firstButtonAction: { viewModel.handleAction(.popBack) },
+      secondButtonAction: { viewModel.handleAction(.tapCloseAlert) }
     )
   }
 }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -117,6 +117,12 @@ struct EditProfileView: View {
       .ignoresSafeArea(.keyboard)
     }
     .toolbar(.hidden, for: .navigationBar)
+    .pcAlert(isPresented: $viewModel.showProfileExitAlert) {
+      profileExitAlert
+    }
+    .pcAlert(isPresented: $viewModel.showImageReexaminationAlert) {
+      imageReexaminationAlert
+    }
     .sheet(isPresented: $viewModel.isLocationSheetPresented) {
       PCBottomSheet<BottomSheetTextItem>(
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isLocationBottomSheetButtonEnable)),
@@ -163,12 +169,6 @@ struct EditProfileView: View {
         onTapRowItem: { viewModel.tapContactRowItem($0) }
       )
       .presentationDetents([.height(479)])
-    }
-    .pcAlert(isPresented: $viewModel.showProfileExitAlert) {
-      profileExitAlert
-    }
-    .pcAlert(isPresented: $viewModel.showImageReexaminationAlert) {
-      imageReexaminationAlert
     }
     .overlay(alignment: .bottom) {
       PCToast(

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -18,6 +18,9 @@ import PCFoundationExtension
 final class EditProfileViewModel {
   enum Action {
     case onAppear
+    case popBack
+    case tapBackButton
+    case tapCloseAlert
     case tapConfirmButton
     case tapVaildNickName
     case selectCamera
@@ -197,6 +200,8 @@ final class EditProfileViewModel {
   }
   var isContactSheetPresented: Bool = false
   var isProfileImageSheetPresented: Bool = false
+  var shouldPopBack: Bool = false
+  var showProfileExitAlert: Bool = false
   var showToast: Bool = false
   var canShowPendingOverlay: Bool {
       imageState == .pending
@@ -210,6 +215,20 @@ final class EditProfileViewModel {
       }
       
       setupJobItemsWithEtc()
+    case .popBack:
+      Task {
+        showProfileExitAlert = false
+        try? await Task.sleep(for: .milliseconds(100))
+        shouldPopBack = true
+      }
+    case .tapBackButton:
+      if isEditing {
+        showProfileExitAlert = true
+      } else {
+        shouldPopBack = true
+      }
+    case .tapCloseAlert:
+      showProfileExitAlert = false
     case .tapConfirmButton:
       Task {
         await handleTapConfirmButton()

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -215,46 +215,33 @@ final class EditProfileViewModel {
     case .onAppear:
       Task {
         await getBasicProfile()
+        setupJobItemsWithEtc()
       }
-      
-      setupJobItemsWithEtc()
     case .popBack:
       Task {
-        showProfileExitAlert = false
+        hideAlerts()
         try? await Task.sleep(for: .milliseconds(100))
-        shouldPopBack = true
+        setPopBack()
       }
     case .tapBackButton:
-      if isEditing {
-        showProfileExitAlert = true
-      } else {
-        shouldPopBack = true
-      }
+      isEditing ? showExitAlert() : setPopBack()
     case .tapCloseAlert:
-      showProfileExitAlert = false
-      showImageReexaminationAlert = false
+      hideAlerts()
     case .tapConfirmButton:
       if imageState == .editing {
         showImageReexaminationAlert = true
       } else {
-        Task {
-          await handleTapConfirmButton()
-        }
+        Task { await handleTapConfirmButton() }
       }
     case .tapConfirmImageReexamination:
       showImageReexaminationAlert = false
-      
-      Task {
-        await handleTapConfirmButton()
-      }
+      Task { await handleTapConfirmButton() }
     case .selectCamera:
       isCameraPresented = true
     case .selectPhotoLibrary:
       isPhotoSheetPresented = true
     case .tapVaildNickName:
-      Task {
-        await handleTapVaildNicknameButton()
-      }
+      Task { await handleTapVaildNicknameButton() }
     case .tapLocation:
       isLocationSheetPresented = true
       updateLocationBottomSheetItems()
@@ -338,7 +325,6 @@ final class EditProfileViewModel {
     updateEditingNicknameState(to: nickNameState)
   }
   
-  @MainActor
   private func showToast(isSuccess: Bool) async {
     toastMessage = isSuccess ? Constant.saveSuccessToastMessage : Constant.saveErrorToastMessage
     
@@ -346,6 +332,19 @@ final class EditProfileViewModel {
     try? await Task.sleep(for: .milliseconds(3000))
     showProfileEditSuccessToast = false
   }
+  
+  private func hideAlerts() {
+    showProfileExitAlert = false
+    showImageReexaminationAlert = false
+  }
+
+  private func showExitAlert() {
+    showProfileExitAlert = true
+  }
+
+  private func setPopBack() {
+    shouldPopBack = true
+  }  
   
   private func isValidBirthDateFormat(_ date: String) -> Bool {
     let dateRegex = #"^(19|20)\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])$"# // YYYYMMDD

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -204,6 +204,8 @@ final class EditProfileViewModel {
   var shouldPopBack: Bool = false
   var showProfileExitAlert: Bool = false
   var showImageReexaminationAlert: Bool = false
+  var showProfileEditSuccessToast: Bool = false
+  var toastMessage: String = Constant.saveSuccessToastMessage
   var canShowPendingOverlay: Bool {
       imageState == .pending
   }
@@ -295,6 +297,7 @@ final class EditProfileViewModel {
     
     if profileImageUrl.isEmpty || !nicknameState.isEnableConfirmButton || !isDescriptionValid || birthDate.isEmpty || location.isEmpty || height.isEmpty || weight.isEmpty || job.isEmpty || !isContactsValid {
       didTapnextButton = true
+      await showToast(isSuccess: false)
     } else {
       do {
         await uploadProfileImageIfNeeded()
@@ -320,8 +323,11 @@ final class EditProfileViewModel {
         updateEditingState()
         updateEditingNicknameState()
         didTapnextButton = false
+        
+        await showToast(isSuccess: true)
       } catch {
         print(error.localizedDescription)
+        await showToast(isSuccess: false)
       }
     }
   }
@@ -333,6 +339,12 @@ final class EditProfileViewModel {
   }
   
   @MainActor
+  private func showToast(isSuccess: Bool) async {
+    toastMessage = isSuccess ? Constant.saveSuccessToastMessage : Constant.saveErrorToastMessage
+    
+    showProfileEditSuccessToast = true
+    try? await Task.sleep(for: .milliseconds(3000))
+    showProfileEditSuccessToast = false
   }
   
   private func isValidBirthDateFormat(_ date: String) -> Bool {
@@ -707,6 +719,8 @@ extension EditProfileViewModel {
 extension EditProfileViewModel {
   private enum Constant {
     static let contactModelCount: Int = 4
+    static let saveSuccessToastMessage: String = "프로필이 수정되었어요"
+    static let saveErrorToastMessage: String = "프로필 수정에 실패했어요"
   }
   
   enum ImageState {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -22,6 +22,7 @@ final class EditProfileViewModel {
     case tapBackButton
     case tapCloseAlert
     case tapConfirmButton
+    case tapConfirmImageReexamination
     case tapVaildNickName
     case selectCamera
     case selectPhotoLibrary
@@ -202,6 +203,7 @@ final class EditProfileViewModel {
   var isProfileImageSheetPresented: Bool = false
   var shouldPopBack: Bool = false
   var showProfileExitAlert: Bool = false
+  var showImageReexaminationAlert: Bool = false
   var showToast: Bool = false
   var canShowPendingOverlay: Bool {
       imageState == .pending
@@ -229,7 +231,18 @@ final class EditProfileViewModel {
       }
     case .tapCloseAlert:
       showProfileExitAlert = false
+      showImageReexaminationAlert = false
     case .tapConfirmButton:
+      if imageState == .editing {
+        showImageReexaminationAlert = true
+      } else {
+        Task {
+          await handleTapConfirmButton()
+        }
+      }
+    case .tapConfirmImageReexamination:
+      showImageReexaminationAlert = false
+      
       Task {
         await handleTapConfirmButton()
       }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -484,9 +484,8 @@ final class EditProfileViewModel {
     smokingStatus != initial.smokingStatus ||
     snsActivityLevel != initial.snsActivityLevel ||
     job != initial.job ||
-    contacts.map { $0.type } != initial.contacts.map { $0.type } ||
-    contacts.map { $0.value } != initial.contacts.map { $0.value }
-    
+    Set(contacts.map { $0.type }) != Set(initial.contacts.map { $0.type }) ||
+    Set(contacts.map { $0.value }) != Set(initial.contacts.map { $0.value })
     isEditing = hasChanges
   }
   private func pendingStateIfNeeded() {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -204,7 +204,6 @@ final class EditProfileViewModel {
   var shouldPopBack: Bool = false
   var showProfileExitAlert: Bool = false
   var showImageReexaminationAlert: Bool = false
-  var showToast: Bool = false
   var canShowPendingOverlay: Bool {
       imageState == .pending
   }
@@ -296,7 +295,6 @@ final class EditProfileViewModel {
     
     if profileImageUrl.isEmpty || !nicknameState.isEnableConfirmButton || !isDescriptionValid || birthDate.isEmpty || location.isEmpty || height.isEmpty || weight.isEmpty || job.isEmpty || !isContactsValid {
       didTapnextButton = true
-      await isToastVisible()
     } else {
       do {
         await uploadProfileImageIfNeeded()
@@ -335,10 +333,6 @@ final class EditProfileViewModel {
   }
   
   @MainActor
-  private func isToastVisible() async {
-    showToast = true
-    try? await Task.sleep(for: .seconds(3))
-    showToast = false
   }
   
   private func isValidBirthDateFormat(_ date: String) -> Bool {


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1013](https://yapp25app3.atlassian.net/browse/PC-1013)

## 👷🏼‍♂️ 변경 사항
### 프로필 알러트 구현
#### 이미지 수정 시
  - 프로필 저장 과정에서 알러트 나타남
  - 알러트에서 확인 시 프로필 저장 API 호출
#### 이미지 제외 수정 시
  - 즉시 프로필 저장 API 호출
#### 수정 후 화면 이탈
  - 알러트 나타남

### 프로필 저장 시 토스트 구현
 - 프로필 저장 성공 및 실패 시 토스트 메시지 나타나나도록 구현

## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 이미지 저장 시 | 화면 이탈 시 |
| :--: | :--: |
| ![Jun-28-2025 22-05-26](https://github.com/user-attachments/assets/30801bc2-9e07-4c22-b471-0418f1429239) | ![Jun-28-2025 22-06-07](https://github.com/user-attachments/assets/d8bcea80-1ade-4861-bdb6-c9dcfa02ee35) |

## 연락처 필드 수정 후 프로필 저장 시 비활성화 되지 않는 이슈 해결
- 서버에서는 연락처 필드의 값을 항상 [카카오톡, 오픈채팅, 인스타, 전화번호]의 **정해진 순서의 배열**로 내려줌.
- App에서는 위 순서가 반드시 정해질 수 없음. (사용자가 연락처 필드의 변경이 가능하기 때문)
- 이를 초깃값과 비교하는 과정에서 배열의 순서가 맞지 않는 문제가 있어 로직 상 수정된 것으로 판단하여 저장 버튼이 비활성화 되지 않게 되었음.
- 배열이 아닌 Set을 사용하여 순서와 무관하게 비교하여 수정된 것으로 판단되지 않도록 함

| 이슈 | 해결 |
| :--: | :--: |
| ![이슈](https://github.com/user-attachments/assets/54c833e8-1b1d-4bb3-a3e8-6222cd9921dd) | ![해결](https://github.com/user-attachments/assets/25b0fba7-3f26-498f-b41b-52d7887c344f) |