### PR TITLE
[PC-1030] Fix: 신고하기 화면에서 뒤로가기 버튼 탭 시 홈 화면이 아닌 이전 화면으로 가도록 수정

### DIFF
--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -26,7 +26,7 @@ struct ReportUserView: View {
     VStack(spacing: 0) {
       NavigationBar(
         title: "신고하기",
-        leftButtonTap: { router.popToRoot() }
+        leftButtonTap: { router.pop() }
       )
       
       ScrollViewReader { proxy in


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1030](https://yapp25app3.atlassian.net/browse/PC-1030)

## 👷🏼‍♂️ 변경 사항
- AS-IS: 신고하기 화면에서 뒤로가기 버튼 탭 시 `popToRoot()`를 호출하여 홈 화면으로 이동
- TO-BE: `pop()`을 호출하여 이전 화면으로 이동
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1030]: https://yapp25app3.atlassian.net/browse/PC-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ