### PR TITLE
[PC-1024] Feat: 매칭 조각 화면 이탈 시 알럿 구현

### DIFF
--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickCard.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickCard.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 struct EditValuePickCard: View {
   @State var viewModel: EditValuePickCardViewModel
+  private let isEditing: Bool
+  
   init(
     valuePick: ProfileValuePickModel,
     isEditing: Bool,
@@ -19,10 +21,10 @@ struct EditValuePickCard: View {
     _viewModel = .init(
       wrappedValue: .init(
         model: valuePick,
-        isEditing: isEditing,
         onModelUpdate: onModelUpdate
       )
     )
+    self.isEditing = isEditing
   }
   
   var body: some View {
@@ -67,11 +69,12 @@ struct EditValuePickCard: View {
     VStack(spacing: 8) {
       ForEach(viewModel.model.answers) { answer in
         SelectCard(
-          isEditing: viewModel.isEditing,
+          isEditing: isEditing,
           isSelected: answer.id == viewModel.model.selectedAnswer,
           text: answer.content,
           tapAction: { viewModel.handleAction(.didTapAnswer(id: answer.id)) }
         )
+        .allowsHitTesting(isEditing)
       }
     }
   }

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickCardModel.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickCardModel.swift
@@ -15,16 +15,13 @@ final class EditValuePickCardViewModel {
   }
   
   let onModelUpdate: (ProfileValuePickModel) -> Void
-  let isEditing: Bool
   var model: ProfileValuePickModel
   
   init(
     model: ProfileValuePickModel,
-    isEditing: Bool,
     onModelUpdate: @escaping (ProfileValuePickModel) -> Void
   ) {
     self.model = model
-    self.isEditing = isEditing
     self.onModelUpdate = onModelUpdate
   }
   

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
@@ -30,7 +30,7 @@ struct EditValuePickView: View {
     VStack(spacing: 0) {
       NavigationBar(
         title: "가치관 Pick",
-        leftButtonTap: { viewModel.handleAction(.tapBackButton) },
+        leftButtonTap: { viewModel.handleAction(.didTapBackButton) },
         rightButton: navigationBarRightButton
       )
       
@@ -86,7 +86,7 @@ struct EditValuePickView: View {
       firstButtonText: "작성 중단하기",
       secondButtonText: "이어서 작성하기",
       firstButtonAction: { viewModel.handleAction(.popBack) },
-      secondButtonAction: { viewModel.handleAction(.tapCloseAlert) }
+      secondButtonAction: { viewModel.handleAction(.didTapCloseAlert) }
     )
   }
   

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
@@ -31,10 +31,7 @@ struct EditValuePickView: View {
       NavigationBar(
         title: "가치관 Pick",
         leftButtonTap: { router.pop() },
-        rightButton: Button { viewModel.handleAction(.didTapSaveButton) } label: {
-          Text(viewModel.isEditing ? "저장": "수정")
-            .foregroundStyle(viewModel.isEditing ? Color.grayscaleDark3 : Color.primaryDefault)
-        }
+        rightButton: navigationBarRightButton
       )
       
       ScrollView {
@@ -45,6 +42,15 @@ struct EditValuePickView: View {
     .frame(maxHeight: .infinity)
     .background(Color.grayscaleWhite)
     .toolbar(.hidden)
+  private var navigationBarRightButton: some View {
+    Button {
+      viewModel.handleAction(.didTapSaveButton)
+    } label: {
+      Text(viewModel.isEditing ? "저장": "수정")
+        .pretendard(.body_M_M)
+        .foregroundStyle(navigationBarRightButtonStyle)
+        .contentShape(Rectangle())
+    }
   }
   
   private var valuePicks: some View {
@@ -62,5 +68,11 @@ struct EditValuePickView: View {
         Divider(weight: .thick)
       }
     }
+  }
+  
+  private var navigationBarRightButtonStyle: Color {
+    viewModel.isEditing
+    ? (viewModel.isEdited ? Color.primaryDefault : Color.grayscaleDark3)
+    : Color.primaryDefault
   }
 }

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
@@ -30,7 +30,7 @@ struct EditValuePickView: View {
     VStack(spacing: 0) {
       NavigationBar(
         title: "가치관 Pick",
-        leftButtonTap: { router.pop() },
+        leftButtonTap: { viewModel.handleAction(.tapBackButton) },
         rightButton: navigationBarRightButton
       )
       
@@ -42,6 +42,14 @@ struct EditValuePickView: View {
     .frame(maxHeight: .infinity)
     .background(Color.grayscaleWhite)
     .toolbar(.hidden)
+    .pcAlert(isPresented: $viewModel.showValuePickExitAlert) {
+      valuePickExitAlert
+    }
+    .onChange(of: viewModel.shouldPopBack) { _, shouldPopBack in
+      if shouldPopBack { router.pop() }
+    }
+  }
+  
   private var navigationBarRightButton: some View {
     Button {
       viewModel.handleAction(.didTapSaveButton)
@@ -68,6 +76,18 @@ struct EditValuePickView: View {
         Divider(weight: .thick)
       }
     }
+  }
+  
+  private var valuePickExitAlert: AlertView<Text> {
+    AlertView(
+      icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
+      title: { Text("작성 중인 프로필이 사라져요!") },
+      message: "지금 뒤로 가면 프로필이 저장되지 않습니다.\n계속 이어서 작성해 보세요.",
+      firstButtonText: "작성 중단하기",
+      secondButtonText: "이어서 작성하기",
+      firstButtonAction: { viewModel.handleAction(.popBack) },
+      secondButtonAction: { viewModel.handleAction(.tapCloseAlert) }
+    )
   }
   
   private var navigationBarRightButtonStyle: Color {

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickViewModel.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickViewModel.swift
@@ -15,6 +15,9 @@ final class EditValuePickViewModel {
   enum Action {
     case updateValuePick(ProfileValuePickModel)
     case didTapSaveButton
+    case popBack
+    case tapBackButton
+    case tapCloseAlert
   }
   
   var valuePicks: [ProfileValuePickModel] = []
@@ -22,6 +25,8 @@ final class EditValuePickViewModel {
   var isEdited: Bool {
     initialValuePicks != valuePicks
   }
+  var showValuePickExitAlert: Bool = false
+  var shouldPopBack: Bool = false
   
   private(set) var initialValuePicks: [ProfileValuePickModel] = []
   private let getProfileValuePicksUseCase: GetProfileValuePicksUseCase
@@ -48,6 +53,15 @@ final class EditValuePickViewModel {
       
     case .didTapSaveButton:
       didTapSaveButton()
+      
+    case .popBack:
+      handlePopBack()
+      
+    case .tapCloseAlert:
+      hideAlert()
+      
+    case .tapBackButton:
+      isEditing ? showExitAlert() : setPopBack()
     }
   }
   
@@ -82,5 +96,28 @@ final class EditValuePickViewModel {
     } catch {
       print(error)
     }
+  }
+  
+  private func handlePopBack() {
+    Task {
+      hideAlert()
+      try? await Task.sleep(for: .milliseconds(100))
+      setPopBack()
+    }
+  }
+}
+
+// MARK: EditValuePick ExitAlert func
+private extension EditValuePickViewModel {
+  func showExitAlert() {
+    showValuePickExitAlert = true
+  }
+  
+  func hideAlert() {
+    showValuePickExitAlert = false
+  }
+  
+  func setPopBack() {
+    shouldPopBack = true
   }
 }

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickViewModel.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickViewModel.swift
@@ -16,8 +16,8 @@ final class EditValuePickViewModel {
     case updateValuePick(ProfileValuePickModel)
     case didTapSaveButton
     case popBack
-    case tapBackButton
-    case tapCloseAlert
+    case didTapBackButton
+    case didTapCloseAlert
   }
   
   var valuePicks: [ProfileValuePickModel] = []
@@ -57,10 +57,10 @@ final class EditValuePickViewModel {
     case .popBack:
       handlePopBack()
       
-    case .tapCloseAlert:
+    case .didTapCloseAlert:
       hideAlert()
       
-    case .tapBackButton:
+    case .didTapBackButton:
       isEditing ? showExitAlert() : setPopBack()
     }
   }

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickViewModel.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickViewModel.swift
@@ -20,7 +20,7 @@ final class EditValuePickViewModel {
   var valuePicks: [ProfileValuePickModel] = []
   var isEditing: Bool = false
   var isEdited: Bool {
-    initialValuePicks == valuePicks
+    initialValuePicks != valuePicks
   }
   
   private(set) var initialValuePicks: [ProfileValuePickModel] = []

--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkView.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkView.swift
@@ -47,7 +47,7 @@ struct EditValueTalkView: View {
       VStack(spacing: 0) {
         NavigationBar(
           title: "가치관 Talk",
-          leftButtonTap: { router.pop() },
+          leftButtonTap: { viewModel.handleAction(.didTapBackButton) },
           rightButton: navigationBarRightButton
         )
         
@@ -71,6 +71,12 @@ struct EditValueTalkView: View {
     }
     .background(Color.grayscaleWhite)
     .toolbar(.hidden)
+    .pcAlert(isPresented: $viewModel.showValueTalkExitAlert) {
+      valueTalkExitAlert
+    }
+    .onChange(of: viewModel.shouldPopBack) { _, shouldPopBack in
+      if shouldPopBack { router.pop() }
+    }
     .onAppear {
       viewModel.handleAction(.onAppear)
     }
@@ -111,5 +117,17 @@ struct EditValueTalkView: View {
         Divider(weight: .thick)
       }
     }
+  }
+  
+  private var valueTalkExitAlert: AlertView<Text> {
+    AlertView(
+      icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
+      title: { Text("작성 중인 프로필이 사라져요!") },
+      message: "지금 뒤로 가면 프로필이 저장되지 않습니다.\n계속 이어서 작성해 보세요.",
+      firstButtonText: "작성 중단하기",
+      secondButtonText: "이어서 작성하기",
+      firstButtonAction: { viewModel.handleAction(.popBack) },
+      secondButtonAction: { viewModel.handleAction(.didTapCloseAlert) }
+    )
   }
 }

--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkViewModel.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkViewModel.swift
@@ -17,6 +17,9 @@ final class EditValueTalkViewModel {
     case updateValueTalk(ProfileValueTalkModel)
     case didTapSaveButton
     case onDisappear
+    case popBack
+    case didTapBackButton
+    case didTapCloseAlert
   }
   
   var valueTalks: [ProfileValueTalkModel] = []
@@ -25,6 +28,8 @@ final class EditValueTalkViewModel {
   var isEdited: Bool {
     initialValueTalks != valueTalks
   }
+  var showValueTalkExitAlert: Bool = false
+  var shouldPopBack: Bool = false
   
   private(set) var initialValueTalks: [ProfileValueTalkModel] = []
   private let getProfileValueTalksUseCase: GetProfileValueTalksUseCase
@@ -69,6 +74,15 @@ final class EditValueTalkViewModel {
       Task {
         await disconnectSse()
       }
+      
+    case .popBack:
+      handlePopBack()
+      
+    case .didTapCloseAlert:
+      hideAlert()
+      
+    case .didTapBackButton:
+      isEditing ? showExitAlert() : setPopBack()
     }
   }
   
@@ -159,5 +173,28 @@ final class EditValueTalkViewModel {
       valueTalks[index].summary = summary.summary
       cardViewModels[index].updateSummary(summary.summary)
     }
+  }
+  
+  private func handlePopBack() {
+    Task {
+      hideAlert()
+      try? await Task.sleep(for: .milliseconds(100))
+      setPopBack()
+    }
+  }
+}
+
+// MARK: EditValueTalk ExitAlert func
+private extension EditValueTalkViewModel {
+  func showExitAlert() {
+    showValueTalkExitAlert = true
+  }
+  
+  func hideAlert() {
+    showValueTalkExitAlert = false
+  }
+  
+  func setPopBack() {
+    shouldPopBack = true
   }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1024](https://yapp25app3.atlassian.net/browse/PC-1024)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - EditValuePick의 수정 및 저장 관련 미구현 된 부분 완료
  - EditValuePick, EditValueTalk에 수정 중 화면 이탈 시 알럿 구현
 
## 💬 참고 사항
- EditValueTalk에 AI 요약 부분 수정 및 저장이 정상 동작 하지 않는 것 같아 추가 구현이 필요해 보입니다.
- 이외 Jira에 ValueTalk 관련 `2차 오프라인 QA`에 추가 이슈가 존재합니다.

## 📸 스크린샷(Optional)
| EditValuePick | EditValueTalk |
| :--: | :--: |
| ![edtc](https://github.com/user-attachments/assets/d198eded-a0bc-4146-aba4-e7b471c139a8) |  ![edta](https://github.com/user-attachments/assets/5c77bfee-bddb-4502-8101-f166dc006748) |

[PC-1024]: https://yapp25app3.atlassian.net/browse/PC-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ