### PR TITLE
[PC-1053] Fix: 웹뷰 화면전환 시 네비게이션 바 숨김 처리

### DIFF
--- a/Presentation/Feature/Settings/Sources/SettingsWebView.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsWebView.swift
@@ -26,7 +26,6 @@ struct SettingsWebView: View {
       )
       
       PCWebView(uri: viewModel.uri)
-        .padding(.bottom, 74)
     }
     .toolbar(.hidden, for: .navigationBar)
     .onAppear {

--- a/Presentation/Feature/Settings/Sources/SettingsWebView.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsWebView.swift
@@ -28,6 +28,7 @@ struct SettingsWebView: View {
       PCWebView(uri: viewModel.uri)
         .padding(.bottom, 74)
     }
+    .toolbar(.hidden, for: .navigationBar)
     .onAppear {
       viewModel.setDismissAction { dismiss() }
     }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1053](https://yapp25app3.atlassian.net/browse/PC-1053)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 웹뷰 화면전환 시 네비게이션 바 숨김 처리
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 수정 전 | 수정 후
| :--: | :--: |
| <img width="316" height="662" alt="image" src="https://github.com/user-attachments/assets/7855bfbc-127b-4d97-81be-23ee725d7a0a" /> |  <img width="311" height="664" alt="image" src="https://github.com/user-attachments/assets/2ec0e820-b4e6-49ef-b0bf-04ebac497a37" /> |


[PC-1053]: https://yapp25app3.atlassian.net/browse/PC-1053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ