### PR TITLE
[PC-1050] Fix: 신고 기능 버튼 활성화 버그 수정

### DIFF
--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -57,7 +57,7 @@ struct ReportUserView: View {
     .pcAlert(isPresented: $viewModel.showBlockAlert) {
       AlertView(
         title: {
-          Text("\(viewModel.nickname)님을\n신고하시겠습니까?")
+          Text("\(viewModel.nickname)님을 신고할까요?")
         },
         message: "신고하면 되돌릴 수 없으니,\n신중한 신고 부탁드립니다.",
         firstButtonText: "취소",
@@ -69,7 +69,7 @@ struct ReportUserView: View {
     .pcAlert(isPresented: $viewModel.showBlockResultAlert) {
       AlertView(
         title: {
-          Text("\(viewModel.nickname)님을 신고했습니다.")
+          Text("\(viewModel.nickname)님을 신고했어요")
         },
         message: "신고된 내용은 신속하게 검토하여\n조치하겠습니다.",
         secondButtonText: "홈으로",
@@ -90,7 +90,7 @@ struct ReportUserView: View {
   }
   
   private var title: some View {
-    Text("\(viewModel.nickname)님을\n신고하시겠습니까?")
+    Text("\(viewModel.nickname)님을 신고할까요?")
       .pretendard(.heading_L_SB)
       .foregroundStyle(.grayscaleBlack)
       .frame(maxWidth: .infinity, alignment: .leading)

--- a/Presentation/Feature/ReportUser/Sources/ReportUserViewModel.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserViewModel.swift
@@ -41,6 +41,7 @@ final class ReportUserViewModel {
     case let .didSelectReportReason(reason):
       selectedReportReason = reason
       showReportReasonEditor = reason == .other
+      updateBottomButtonEnabled()
       
     case .didTapNextButton:
       showBlockAlert = true
@@ -48,6 +49,7 @@ final class ReportUserViewModel {
     case let .didUpdateReportReason(reason):
       let limitedText = reason.count <= 100 ? reason : String(reason.prefix(100))
       reportReason = limitedText
+      updateBottomButtonEnabled()
       
     case .didTapReportButton:
       showBlockAlert = false
@@ -59,11 +61,23 @@ final class ReportUserViewModel {
     do {
       let reason = selectedReportReason == .other ? reportReason : selectedReportReason?.rawValue ?? ""
       if let id = PCUserDefaultsService.shared.getMatchedUserId() {
-        let result = try await reportUserUseCase.execute(id: id, reason: reason)
+        _ = try await reportUserUseCase.execute(id: id, reason: reason)
         showBlockResultAlert = true
       }
     } catch {
       print(error)
+    }
+  }
+  
+  private func updateBottomButtonEnabled() {
+    if let selected = selectedReportReason {
+      if selected == .other {
+        isBottomButtonEnabled = !reportReason.isEmpty
+      } else {
+        isBottomButtonEnabled = true
+      }
+    } else {
+      isBottomButtonEnabled = false
     }
   }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1050](https://yapp25app3.atlassian.net/browse/PC-1050)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 구현되지 않은 신고 화면의 다음버튼 활성화 구현
  - enable 값의 mutating은 하나의 `updateBottomButtonEnabled()` 메서드에서 담당하도록 구현함.
  - 기타 탭 활성화는 요구사항 명시가 되어있지 않아 그냥 empty가 아닐 때만 활성화하도록 구현함.
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용
- 이거 신고하고 홈 화면 돌아가면 신고한 유저 그대로 남아있고, 신고 계속할 수 있는 것 같음
- 홈 화면의 match info는 다시 불러오고 있음

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
| ![Jul-16-2025 23-29-36](https://github.com/user-attachments/assets/a19c960a-4ca2-4e48-b90f-858088015376) |