### PR TITLE
[PC-1052] Fix: 매칭 결과 화면 이슈 해결 및 UX Writing 수정 반영

### DIFF
--- a/Presentation/DesignSystem/Sources/AlertView.swift
+++ b/Presentation/DesignSystem/Sources/AlertView.swift
@@ -125,17 +125,17 @@ private struct AlertBottomView: View {
     Color.grayscaleBlack.ignoresSafeArea()
     VStack{
       AlertView(
-        title: { Text("수줍은 수달").foregroundColor(.primaryDefault) + Text("님과의\n인연을 이어가시겠습니까?") },
-        message: "서로 매칭을 수락하면, 연락처가 공개됩니다.",
+        title: { Text("수줍은 수달").foregroundColor(.primaryDefault) + Text("님과의\n인연을 이어갈까요?") },
+        message: "서로 수락하면, 연락처가 공개돼요.",
         firstButtonText: "뒤로",
-        secondButtonText: "매칭 수락하기",
+        secondButtonText: "인연 수락하기",
         firstButtonAction: {},
         secondButtonAction: {}
       )
       AlertView(
         icon: DesignSystemAsset.Icons.matchingModeCheck20.swiftUIImage,
-        title: { Text("수줍은 수달님과의 인연을 이어가시겠습니까?") },
-        message: "서로 매칭을 수락하면, 연락처가 공개됩니다.",
+        title: { Text("수줍은 수달님과의 인연을 이어갈까요?") },
+        message: "서로 수락하면, 연락처가 공개돼요.",
         firstButtonText: "label",
         secondButtonText: "label",
         firstButtonAction: {},
@@ -144,8 +144,8 @@ private struct AlertBottomView: View {
       
       AlertView(
         icon: DesignSystemAsset.Icons.matchingModeCheck20.swiftUIImage,
-        title: { Text("수줍은 수달님과의 인연을 이어가시겠습니까?") },
-        message: "서로 매칭을 수락하면, 연락처가 공개됩니다.",
+        title: { Text("수줍은 수달님과의 인연을 이어갈까요?") },
+        message: "서로 수락하면, 연락처가 공개돼요.",
         secondButtonText: "label",
         secondButtonAction: {}
       )

--- a/Presentation/Feature/BlockUser/Sources/BlockUserView.swift
+++ b/Presentation/Feature/BlockUser/Sources/BlockUserView.swift
@@ -39,7 +39,7 @@ struct BlockUserView: View {
     .pcAlert(isPresented: $viewModel.isBlockUserAlertPresented) {
       AlertView(
         title: {
-          Text("\(viewModel.nickname)님을\n차단하시겠습니까?")
+          Text("\(viewModel.nickname)님을 차단할까요?")
             .pretendard(.heading_M_SB)
             .foregroundStyle(Color.grayscaleBlack)
         },
@@ -59,7 +59,7 @@ struct BlockUserView: View {
             .pretendard(.heading_M_SB)
             .foregroundStyle(Color.grayscaleBlack)
         },
-        message: "매칭이 즉시 종료되며,\n상대방에게 차단 사실을 알리지 않습니다.",
+        message: "상대방과의 만남이 즉시 종료됩니다.",
         secondButtonText: "홈으로"
       ) {
         viewModel.handleAction(.didTapBlockUserCompleteButton)
@@ -81,11 +81,11 @@ struct BlockUserView: View {
   
   private var title: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("\(viewModel.nickname)님을\n차단하시겠습니까?")
+      Text("\(viewModel.nickname)님을 차단할까요?")
         .pretendard(.heading_L_SB)
         .foregroundStyle(Color.grayscaleBlack)
       
-      Text("차단하면 상대방의 매칭이 즉시 종료되며,\n상대방에게 차단 사실을 알리지 않습니다.")
+      Text("하단 내용을 확인해 주세요.")
         .pretendard(.body_S_M)
         .foregroundStyle(Color.grayscaleDark3)
     }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -128,7 +128,7 @@ struct EditProfileView: View {
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isLocationBottomSheetButtonEnable)),
         items: $viewModel.locationItems,
         titleText: "활동 지역",
-        subtitleText: "주로 활동하는 지역을 선택해주세요.",
+        subtitleText: "주로 활동하는 지역을 선택해 주세요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveLocation) },
         onTapRowItem: { viewModel.tapLocationRowItem($0) }
@@ -151,7 +151,7 @@ struct EditProfileView: View {
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
         items: $viewModel.contactBottomSheetItems,
         titleText: "연락처",
-        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        subtitleText: "공개하고 싶은 연락처를 선택해 주세요.\n1개 이상 필수로 작성해야 해요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveContact) },
         onTapRowItem: { viewModel.tapContactRowItem($0) }
@@ -163,7 +163,7 @@ struct EditProfileView: View {
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
         items: $viewModel.contactBottomSheetItems,
         titleText: "연락처",
-        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        subtitleText: "공개하고 싶은 연락처를 선택해 주세요.\n1개 이상 필수로 작성해야 해요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.editContact) },
         onTapRowItem: { viewModel.tapContactRowItem($0) }
@@ -308,7 +308,7 @@ struct EditProfileView: View {
   }
   
   private var profileImageDescriptionLabel: some View {
-    Text("얼굴이 잘 나온 사진으로 등록해 주세요.")
+    Text("얼굴이 잘 보이는 사진으로 등록해 주세요.")
       .pretendard(.body_S_M)
       .foregroundStyle(Color.grayscaleDark3)
   }
@@ -525,8 +525,8 @@ struct EditProfileView: View {
   private var profileExitAlert: AlertView<Text> {
     AlertView(
       icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
-      title: { Text("작성 중인 프로필이 사라져요!") },
-      message: "지금 뒤로 가면 프로필이 저장되지 않습니다.\n계속 이어서 작성해 보세요.",
+      title: { Text("작성한 내용이 사라져요!") },
+      message: "지금 뒤로 가면 프로필이 저장되지 않아요.\n계속 이어서 작성해 보세요.",
       firstButtonText: "작성 중단하기",
       secondButtonText: "이어서 작성하기",
       firstButtonAction: { viewModel.handleAction(.popBack) },
@@ -537,8 +537,8 @@ struct EditProfileView: View {
   private var imageReexaminationAlert: AlertView<Text> {
     AlertView(
       icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
-      title: { Text("사진은 심사 통과 후 반영됩니다!") },
-      message: "안전한 커뮤니티를 위해 사진은 수정 시\n심사를 다시 진행해요. 신중하게 변경해 주세요!",
+      title: { Text("수정된 사진은 심사가 필요해요!") },
+      message: "안전한 커뮤니티를 위해 사진을 다시 심사해요.\n심사 중에는 이전 사진으로 매칭이 진행돼요",
       firstButtonText: "뒤로",
       secondButtonText: "변경하기",
       firstButtonAction: { viewModel.handleAction(.tapCloseAlert) },

--- a/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
+++ b/Presentation/Feature/EditValuePick/Sources/EditValuePickView.swift
@@ -81,8 +81,8 @@ struct EditValuePickView: View {
   private var valuePickExitAlert: AlertView<Text> {
     AlertView(
       icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
-      title: { Text("작성 중인 프로필이 사라져요!") },
-      message: "지금 뒤로 가면 프로필이 저장되지 않습니다.\n계속 이어서 작성해 보세요.",
+      title: { Text("작성한 내용이 사라져요!") },
+      message: "지금 뒤로 가면 프로필이 저장되지 않아요.\n계속 이어서 작성해 보세요.",
       firstButtonText: "작성 중단하기",
       secondButtonText: "이어서 작성하기",
       firstButtonAction: { viewModel.handleAction(.popBack) },

--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkView.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkView.swift
@@ -122,8 +122,8 @@ struct EditValueTalkView: View {
   private var valueTalkExitAlert: AlertView<Text> {
     AlertView(
       icon: DesignSystemAsset.Icons.notice40.swiftUIImage,
-      title: { Text("작성 중인 프로필이 사라져요!") },
-      message: "지금 뒤로 가면 프로필이 저장되지 않습니다.\n계속 이어서 작성해 보세요.",
+      title: { Text("작성한 내용이 사라져요!") },
+      message: "지금 뒤로 가면 프로필이 저장되지 않아요.\n계속 이어서 작성해 보세요.",
       firstButtonText: "작성 중단하기",
       secondButtonText: "이어서 작성하기",
       firstButtonAction: { viewModel.handleAction(.popBack) },

--- a/Presentation/Feature/Home/Sources/HomeView.swift
+++ b/Presentation/Feature/Home/Sources/HomeView.swift
@@ -72,7 +72,7 @@ struct HomeView: View {
       PCToast(
         isVisible: $showProfileToast,
         icon: DesignSystemAsset.Icons.notice20.swiftUIImage,
-        text: "아직 심사중이에요"
+        text: "아직 프로필을 심사하고 있어요"
       )
       .padding(.bottom, 100)
       

--- a/Presentation/Feature/Login/Sources/Login/LoginView.swift
+++ b/Presentation/Feature/Login/Sources/Login/LoginView.swift
@@ -78,23 +78,21 @@ struct LoginView: View {
       guard let newValue else { return }
       router.setRoute(newValue)
     }
-    .pcAlert(
-      isPresented: $viewModel.showBannedAlert,
-      alert: {
-        AlertView(
-          title: {
-            Text("계정 이용이 영구 제한되었습니다.")
-              .pretendard(.heading_M_SB)
-              .foregroundStyle(.grayscaleBlack)
-          },
-          message: "궁금한 점이 있다면 고객센터로 문의해주세요.",
-          firstButtonText: "문의하기",
-          secondButtonText: "종료",
-          firstButtonAction: { router.push(to: .settingsWebView(title: "문의하기", uri: viewModel.inquiriesUri)) },
-          secondButtonAction: { exit(0) }
-        )
-      }
-    )
+    .pcAlert(isPresented: $viewModel.showBannedAlert) {
+      AlertView(
+        icon: DesignSystemAsset.Icons.notice40.swiftUIImage ,
+        title: {
+          Text("계정 이용이 영구 제한되었어요")
+            .pretendard(.heading_M_SB)
+            .foregroundStyle(.grayscaleBlack)
+        },
+        message: "궁금한 점이 있다면 고객센터로 문의해 주세요.",
+        firstButtonText: "문의하기",
+        secondButtonText: "종료",
+        firstButtonAction: { router.push(to: .settingsWebView(title: "문의하기", uri: viewModel.inquiriesUri)) },
+        secondButtonAction: { exit(0) }
+      )
+    }
     .alert("테스트 로그인 비밀번호를 입력해주세요", isPresented: $viewModel.showTestPasswordAlert) {
       TextField("", text: $viewModel.testPassword)
       Button("확인") {

--- a/Presentation/Feature/MatchResult/Sources/MatchResultView.swift
+++ b/Presentation/Feature/MatchResult/Sources/MatchResultView.swift
@@ -65,7 +65,7 @@ struct MatchResultView: View {
   
   private var headerText: some View {
     VStack(alignment: .center, spacing: 8) {
-      Group { Text(viewModel.nickname).foregroundStyle(.primaryDefault) + Text("님과 퍼즐 완성 !").foregroundStyle(.grayscaleBlack) }
+      Group { Text(viewModel.nickname).foregroundStyle(.primaryDefault) + Text("님과 마음이 통했어요!").foregroundStyle(.grayscaleBlack) }
         .pretendard(.heading_L_SB)
      Text("망설이지 말고 연락해 보세요\n두 분의 평화로운 사랑을 피스가 응원해요")
         .multilineTextAlignment(.center)

--- a/Presentation/Feature/MatchResult/Sources/MatchResultView.swift
+++ b/Presentation/Feature/MatchResult/Sources/MatchResultView.swift
@@ -60,6 +60,7 @@ struct MatchResultView: View {
         .ignoresSafeArea()
     )
     .onAppear { viewModel.handleAction(.onAppear) }
+    .toolbar(.hidden, for: .navigationBar)
   }
   
   private var headerText: some View {

--- a/Presentation/Feature/MatchingDetail/Sources/Common/MatchDetailPhotoView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/Common/MatchDetailPhotoView.swift
@@ -71,7 +71,7 @@ struct MatchDetailPhotoView: View {
       
       RoundedButton(
         type: isAcceptButtonEnabled ? .solid : .disabled,
-        buttonText: "매칭 수락하기",
+        buttonText: "인연 수락하기",
         rounding: true
       ) {
         if isAcceptButtonEnabled { isAlertPresented.toggle() }
@@ -81,11 +81,11 @@ struct MatchDetailPhotoView: View {
       AlertView(
         title: {
           Text("\(nickname)").foregroundStyle(Color.primaryDefault) +
-          Text("님과의\n인연을 이어가시겠습니까?").foregroundStyle(Color.grayscaleBlack)
+          Text("님과의\n인연을 이어갈까요?").foregroundStyle(Color.grayscaleBlack)
         },
-        message: "서로 매칭을 수락하면, 연락처가 공개됩니다.",
+        message: "서로 수락하면, 연락처가 공개돼요.",
         firstButtonText: "뒤로",
-        secondButtonText: "매칭 수락하기"
+        secondButtonText: "인연 수락하기"
       ) {
         isAlertPresented = false
       } secondButtonAction: {

--- a/Presentation/Feature/MatchingDetail/Sources/MatchProfileBasic/MatchProfileBasicViewModel.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/MatchProfileBasic/MatchProfileBasicViewModel.swift
@@ -18,7 +18,7 @@ final class MatchProfileBasicViewModel {
   
   private enum Constant {
     static let navigationTitle = ""
-    static let title = "오늘의 매칭 조각"
+    static let title = "오늘의 인연"
   }
 
   let navigationTitle = Constant.navigationTitle

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
@@ -14,8 +14,8 @@ import UseCases
 struct ValuePickView: View {
   private enum Constant {
     static let horizontalPadding: CGFloat = 20
-    static let accepetButtonText = "매칭 수락하기"
-    static let refuseButtonText = "매칭 거절하기"
+    static let accepetButtonText = "인연 수락하기"
+    static let refuseButtonText = "인연 거절하기"
   }
   
   @State var viewModel: ValuePickViewModel
@@ -97,11 +97,11 @@ struct ValuePickView: View {
       AlertView(
         title: {
           Text("\(viewModel.valuePickModel?.nickname ?? "")").foregroundStyle(Color.primaryDefault) +
-          Text("님과의\n인연을 이어가시겠습니까?").foregroundStyle(Color.grayscaleBlack)
+          Text("님과의\n인연을 이어갈까요?").foregroundStyle(Color.grayscaleBlack)
         },
-        message: "서로 매칭을 수락하면, 연락처가 공개됩니다.",
+        message: "서로 수락하면 연락처가 공개돼요.",
         firstButtonText: "뒤로",
-        secondButtonText: "매칭 수락하기"
+        secondButtonText: Constant.accepetButtonText
       ) {
         viewModel.isMatchAcceptAlertPresented = false
       } secondButtonAction: {
@@ -115,11 +115,11 @@ struct ValuePickView: View {
           Text("\(viewModel.valuePickModel?.nickname ?? "")님과의\n").foregroundStyle(Color.grayscaleBlack) +
           Text("인연을 ").foregroundStyle(Color.grayscaleBlack) +
           Text("거절").foregroundStyle(Color.systemError) +
-          Text("하시겠습니까?").foregroundStyle(Color.grayscaleBlack)
+          Text("할까요?").foregroundStyle(Color.grayscaleBlack)
         },
         message: "매칭을 거절하면 이후에 되돌릴 수 없으니\n신중히 선택해 주세요.",
         firstButtonText: "뒤로",
-        secondButtonText: "매칭 거절하기"
+        secondButtonText: Constant.refuseButtonText
       ) {
         viewModel.isMatchDeclineAlertPresented = false
       } secondButtonAction: {

--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
@@ -67,11 +67,11 @@ struct MatchingMainView: View {
       AlertView(
         title: {
           Text("\(matchingMainViewModel.name)").foregroundStyle(Color.primaryDefault) +
-          Text("님과의\n인연을 이어가시겠습니까?").foregroundStyle(Color.grayscaleBlack)
+          Text("님과의\n인연을 이어갈까요?").foregroundStyle(Color.grayscaleBlack)
         },
-        message: "서로 매칭을 수락하면, 연락처가 공개됩니다.",
+        message: "서로 수락하면, 연락처가 공개돼요.",
         firstButtonText: "뒤로",
-        secondButtonText: "매칭 수락하기"
+        secondButtonText: "인연 수락하기"
       ) {
         matchingMainViewModel.isMatchAcceptAlertPresented = false
       } secondButtonAction: {
@@ -145,11 +145,11 @@ struct MatchingMainView: View {
           Group {
             Text("진중한 만남")
               .foregroundStyle(Color.primaryDefault) +
-            Text("을 이어가기 위해\n프로필을 살펴보고 있어요")
+            Text("을 이어가기 위해\n프로필을 살펴보고 있어요.")
               .foregroundStyle(Color.grayscaleBlack)
           }
           .pretendard(.heading_M_SB)
-          Text("작성 후 24시간 이내에 심사가 진행됩니다.\n생성한 프로필을 검토하며 기다려 주세요.")
+          Text("작성 후 24시간 이내에 심사가 진행돼요.\n푸쉬 알림을 켜면 결과를 빠르게 확인할 수 있어요.")
             .pretendard(.body_S_M)
             .foregroundStyle(Color.grayscaleDark3)
         }

--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
@@ -20,7 +20,7 @@ final class MatchingMainViewModel {
   enum MatchingButtonState {
     case pending
     case checkMatchingPiece // 매칭 조각 확인하기
-    case acceptMatching // 매칭 수락하기
+    case acceptMatching // 인연 수락하기
     case responseComplete // 응답 완료
     case checkContact(nickname: String) // 연락처 확인하기
     
@@ -31,11 +31,11 @@ final class MatchingMainViewModel {
       case .checkMatchingPiece:
         "매칭 조각 확인하기"
       case .acceptMatching:
-        "매칭 수락하기"
+        "인연 수락하기"
       case .responseComplete:
         "응답 완료"
       case .checkContact:
-        "연락처 확인하기"
+        "인연 확인하기"
       }
     }
     
@@ -62,7 +62,7 @@ final class MatchingMainViewModel {
   enum Action {
     case tapProfileInfo // 매칭 조각 확인하고 상대 프로필 눌렀을때
     case tapMatchingButton // 하단 CTA 매칭 버튼 누를시
-    case didAcceptMatch // 매칭 수락하기
+    case didAcceptMatch // 인연 수락하기
   }
   var userRole: String {
     PCUserDefaultsService.shared.getUserRole().rawValue
@@ -199,7 +199,7 @@ final class MatchingMainViewModel {
         matchingStatus = .BEFORE_OPEN
         matchingButtonState = .checkMatchingPiece
       case .WAITING:
-        //자신은 매칭조각 열람, 상대는 매칭 수락 안함(열람했는지도 모름)
+        //자신은 매칭조각 열람, 상대는 인연 수락 안함(열람했는지도 모름)
         matchingStatus = .WAITING
         matchingButtonState = .acceptMatching
       case .REFUSED:

--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
@@ -216,7 +216,7 @@ final class MatchingMainViewModel {
       case .MATCHED:
           // 둘다 수락
         matchingStatus = .MATCHED
-        matchingButtonState = .checkContact(nickname: "")
+        matchingButtonState = .checkContact(nickname: matchesInfo.nickname)
       }
       
       name = matchesInfo.nickname

--- a/Presentation/Feature/Profile/Sources/ProfileView.swift
+++ b/Presentation/Feature/Profile/Sources/ProfileView.swift
@@ -235,7 +235,7 @@ struct ProfileView: View {
       SettingCategory(
         icon: DesignSystemAsset.Icons.question20.swiftUIImage,
         categoryText: "가치관 Pick",
-        descriptionText: "퀴즈를 통해 나의 연애 스타일을 파악해보고\n선택한 답변을 수정할 수 있습니다."
+        descriptionText: "퀴즈를 통해 나의 연애 스타일을 파악해보고\n선택한 답변을 수정할 수 있어요."
       )
       .contentShape(Rectangle())
       .onTapGesture {
@@ -247,7 +247,7 @@ struct ProfileView: View {
       SettingCategory(
         icon: DesignSystemAsset.Icons.talk20.swiftUIImage,
         categoryText: "가치관 Talk",
-        descriptionText: "꿈과 목표, 관심사와 취향, 연애에 관련된\n내 생각을 확인하고 수정할 수 있습니다."
+        descriptionText: "꿈과 목표, 관심사와 취향, 연애에 관련된\n내 생각을 확인하고 수정할 수 있어요."
       )
       .contentShape(Rectangle())
       .onTapGesture {

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -162,7 +162,7 @@ struct CreateBasicInfoView: View {
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isLocationBottomSheetButtonEnable)),
         items: $viewModel.locationItems,
         titleText: "활동 지역",
-        subtitleText: "주로 활동하는 지역을 선택해주세요.",
+        subtitleText: "주로 활동하는 지역을 선택해 주세요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveLocation) },
         onTapRowItem: { viewModel.tapLocationRowItem($0) }
@@ -185,7 +185,7 @@ struct CreateBasicInfoView: View {
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
         items: $viewModel.contactBottomSheetItems,
         titleText: "연락처",
-        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        subtitleText: "공개하고 싶은 연락처를 선택해 주세요.\n1개 이상 필수로 작성해야 해요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.saveContact) },
         onTapRowItem: { viewModel.tapContactRowItem($0) }
@@ -197,7 +197,7 @@ struct CreateBasicInfoView: View {
         isButtonEnabled: Binding(projectedValue: .constant(viewModel.isContactBottomSheetButtonEnable)),
         items: $viewModel.contactBottomSheetItems,
         titleText: "연락처",
-        subtitleText: "연락을 주고받고 싶은 연락처를 선택해 작성해주세요.\n1개 이상 필수로 작성해야 합니다.",
+        subtitleText: "공개하고 싶은 연락처를 선택해 주세요.\n1개 이상 필수로 작성해야 해요.",
         buttonText: "적용하기",
         buttonAction: { viewModel.handleAction(.editContact) },
         onTapRowItem: { viewModel.tapContactRowItem($0) }
@@ -208,10 +208,10 @@ struct CreateBasicInfoView: View {
   
   private var title: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("간단한 정보로\n당신을 표현하세요")
+      Text("간단한 정보로\n당신을 표현해 주세요")
         .pretendard(.heading_L_SB)
         .foregroundStyle(Color.grayscaleBlack)
-      Text("작성 후에도 언제든 수정 가능하니,\n편안하게 작성해 주세요.")
+      Text("작성 후에도 언제든 수정할 수 있어요.")
         .pretendard(.body_S_M)
         .foregroundStyle(Color.grayscaleDark3)
     }
@@ -259,7 +259,7 @@ struct CreateBasicInfoView: View {
   }
   
   private var profileImageDescriptionLabel: some View {
-    Text("얼굴이 잘 나온 사진으로 등록해 주세요.")
+    Text("얼굴이 잘 보이는 사진으로 등록해 주세요.")
       .pretendard(.body_S_M)
       .foregroundStyle(Color.grayscaleDark3)
   }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/ValuePick/ValuePickView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/ValuePick/ValuePickView.swift
@@ -60,7 +60,7 @@ struct ValuePickView: View {
         .foregroundStyle(Color.grayscaleBlack)
         .frame(maxWidth: .infinity, alignment: .leading)
       
-      Text("선택한 답변으로 연애 스타일을 쉽게 확인할 수 있어요.\n서로의 우선순위와 취향을 이해하는 데 큰 도움이 될 거예요.")
+      Text("선택 후에도 언제든 수정할 수 있어요.")
         .pretendard(.body_S_M)
         .foregroundStyle(Color.grayscaleDark3)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
@@ -79,7 +79,7 @@ private extension WithdrawConfirmView {
           .pretendard(.heading_L_SB)
           .foregroundStyle(.grayscaleBlack)
         
-        Text("탈퇴하면 계정과 관련된 모든 정보가 삭제되며\n복구할 수 없습니다. 탈퇴하시겠습니까?")
+        Text("탈퇴하면 계정과 관련된 모든 정보가 삭제되며\n복구할 수 없습니다.")
           .pretendard(.body_S_M)
           .foregroundStyle(.grayscaleDark3)
       }

--- a/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
@@ -87,7 +87,7 @@ private extension WithdrawView {
         .pretendard(.heading_L_SB)
         .foregroundStyle(.grayscaleBlack)
       
-      Text("탈퇴하는 이유를 알려주세요.\n반영하여 더 나은 사용자 경험을 제공하겠습니다.")
+      Text("탈퇴하는 이유를 알려주세요.\n반영하여 더 나은 사용자 경험을 제공할게요!")
         .pretendard(.body_S_M)
         .foregroundStyle(.grayscaleDark3)
     }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1052](https://yapp25app3.atlassian.net/browse/PC-1052)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 상호 매칭 수락 후 이어지는 화면의 네비게이션 바가 중복되는 버그를 해결했습니다.
  - 상호 매칭 수락 후 이어지는 화면의 상대 닉네임이 누락되는 버그를 해결했습니다.
  - **바로 적용 가능한 UX Writing 수정 사항**을 **모두** 반영했습니다.
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1052]: https://yapp25app3.atlassian.net/browse/PC-1052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ