### PR TITLE
[PC-1051] Fix: 차단된 상태의 유저가 매칭에 보이지 않도록 수정

### DIFF
--- a/Data/DTO/Sources/Matches/MatchInfosResponseDTO.swift
+++ b/Data/DTO/Sources/Matches/MatchInfosResponseDTO.swift
@@ -19,6 +19,7 @@ public struct MatchInfosResponseDTO: Decodable {
   public let job: String
   public let matchedValueCount: Int
   public let matchedValueList: [String]
+  public let blocked: Bool
 }
 
 public extension MatchInfosResponseDTO {
@@ -33,7 +34,8 @@ public extension MatchInfosResponseDTO {
       location: location,
       job: job,
       matchedValueCount: matchedValueCount,
-      matchedValueList: matchedValueList
+      matchedValueList: matchedValueList,
+      blocked: blocked
     )
   }
 }

--- a/Domain/Entities/Sources/MatchMain/MatchInfosModel.swift
+++ b/Domain/Entities/Sources/MatchMain/MatchInfosModel.swift
@@ -18,6 +18,7 @@ public struct MatchInfosModel {
   public let job: String
   public let matchedValueCount: Int
   public let matchedValueList: [String]
+  public let blocked: Bool
   
   public init(
     matchId: Int,
@@ -29,7 +30,8 @@ public struct MatchInfosModel {
     location: String,
     job: String,
     matchedValueCount: Int,
-    matchedValueList: [String]
+    matchedValueList: [String],
+    blocked: Bool
   ) {
     self.matchId = matchId
     self.matchedUserId = matchedUserId
@@ -41,5 +43,6 @@ public struct MatchInfosModel {
     self.job = job
     self.matchedValueCount = matchedValueCount
     self.matchedValueList = matchedValueList
+    self.blocked = blocked
   }
 }

--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
@@ -191,7 +191,6 @@ final class MatchingMainViewModel {
     do {
       let matchesInfo = try await getMatchesInfoUseCase.execute() // 매칭 상태 확인해야함
       let matchStatus = matchesInfo.matchStatus
-      isShowMatchingMainBasicCard = true
       
       switch matchStatus {
       case .BEFORE_OPEN:
@@ -226,6 +225,12 @@ final class MatchingMainViewModel {
       job = matchesInfo.job
       tags = matchesInfo.matchedValueList
       
+      if matchesInfo.blocked {
+        isShowMatchingNodataCard = true
+        matchingButtonState = .pending
+      } else {
+        isShowMatchingMainBasicCard = true
+      }
     } catch {
       print("Get Match Status :\(error.localizedDescription)")
       isShowMatchingNodataCard = true


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1051](https://yapp25app3.atlassian.net/browse/PC-1051)

## 👷🏼‍♂️ 변경 사항
- 관련 DTO에 누락되어있던`blocked`를 추가했습니다.
- 매칭된 유저를 차단한 경우 홈 화면에서 해당 유저가 보이지 않도록 수정했습니다.
- 매칭-차단 플로우에서 매칭 상대 차단 시, 홈 화면으로 이동하며 아래 스크린샷과 같은 결과를 보여줍니다.
 
## 💬 참고 사항
- 추후 다중 매칭이 가능해지면 전부 갈아 엎어야 될 것 같아서 너무 슬프네요
- 차단, 차단 해제, 매칭 등등 권한이 없어서 API 테스트가 굉장히 불편하네요..


## 📸 스크린샷(Optional)
| 매칭된 상태의 유저가 존재하지만 `blocked`가 `true`인 경우 pending 화면을 보여준다 |
| :--: |
| <img width="935" height="690" alt="image" src="https://github.com/user-attachments/assets/deccc54e-4dda-4265-907d-ef0b7ef113f2" /> |

[PC-1051]: https://yapp25app3.atlassian.net/browse/PC-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ