### PR TITLE
[PC-1048] Feature: ValueTalk의 최소 글자 제한 기능 추가

### DIFF
--- a/Presentation/DesignSystem/Sources/TextCountIndicator.swift
+++ b/Presentation/DesignSystem/Sources/TextCountIndicator.swift
@@ -9,15 +9,28 @@ import SwiftUI
 
 public struct TextCountIndicator: View {
   @Binding public var count: Int
+  private let minCount: Int?
   private let maxCount: Int
   
-  public init(count: Binding<Int>, maxCount: Int) {
+  public init(
+    count: Binding<Int>,
+    minCount: Int? = nil,
+    maxCount: Int
+  ) {
     self._count = count
+    self.minCount = minCount
     self.maxCount = maxCount
   }
   
   public var body: some View {
     HStack(spacing: 0) {
+      if let minCount,
+      minCount > count {
+        Text("\(minCount)자 이상 작성해 주세요.")
+          .pretendard(.body_S_M)
+          .foregroundStyle(Color.systemError)
+        Spacer()
+      }
       Text(count.description)
         .pretendard(.body_S_M)
         .foregroundStyle(Color.primaryDefault)
@@ -30,5 +43,7 @@ public struct TextCountIndicator: View {
 }
 
 #Preview {
+  TextCountIndicator(count: .constant(15), minCount: 30, maxCount: 300)
+  TextCountIndicator(count: .constant(150), minCount: 30, maxCount: 300)
   TextCountIndicator(count: .constant(150), maxCount: 300)
 }

--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkCard.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkCard.swift
@@ -11,6 +11,12 @@ import SwiftUI
 import PCFoundationExtension
 
 struct EditValueTalkCard: View {
+  private enum Constants {
+    static let minAnswerCount: Int = 30
+    static let maxAnswerCount: Int = 300
+    static let valueTalkMinHeight: Double = 96.0
+  }
+  
   @Bindable private var viewModel: EditValueTalkCardViewModel
   private var focusState: FocusState<EditValueTalkView.Field?>.Binding
   let id: Int
@@ -22,7 +28,7 @@ struct EditValueTalkCard: View {
     index: Int,
     isEditing: Bool
   ) {
-    _viewModel = .init(wrappedValue: viewModel)
+    self.viewModel = viewModel
     self.focusState = focusState
     self.id = index
     self.isEditing = isEditing
@@ -41,16 +47,14 @@ struct EditValueTalkCard: View {
       answer
       Spacer()
         .frame(height: 12)
-      if viewModel.isEditingAnswer {
+      if isEditing {
         guide
           .contentShape(Rectangle())
           .onTapGesture {
             // 도움말 영역 탭 시 포커스 해제
             focusState.wrappedValue = nil
           }
-      }
-      
-      if !viewModel.isEditingAnswer {
+      } else {
         Spacer()
           .frame(height: 20)
         summary
@@ -92,7 +96,7 @@ struct EditValueTalkCard: View {
         get: { viewModel.model.answer },
         set: { viewModel.handleAction(.didUpdateAnswer($0)) }
       ))
-      .frame(maxWidth: .infinity, minHeight: 96, maxHeight: .infinity)
+      .frame(maxWidth: .infinity, minHeight: Constants.valueTalkMinHeight, maxHeight: .infinity)
       .fixedSize(horizontal: false, vertical: true)
       .pretendard(.body_M_M)
       .autocorrectionDisabled()
@@ -115,8 +119,14 @@ struct EditValueTalkCard: View {
         }
       }
       
-      TextCountIndicator(count: .constant(viewModel.model.answer.count), maxCount: 300)
+      if isEditing {
+        TextCountIndicator(
+          count: .constant(viewModel.model.answer.count),
+          minCount: Constants.minAnswerCount,
+          maxCount: Constants.maxAnswerCount
+        )
         .opacity(!viewModel.model.answer.isEmpty || focusState.wrappedValue == .answerEditor(viewModel.model.id) ? 1 : 0)
+      }
     }
     .padding(.horizontal, 16)
     .padding(.vertical, 14)

--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkView.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkView.swift
@@ -94,7 +94,7 @@ struct EditValueTalkView: View {
         .pretendard(.body_M_M)
         .foregroundStyle(
           viewModel.isEditing
-          ? (viewModel.isEdited ? Color.primaryDefault : Color.grayscaleDark3)
+          ? (viewModel.isAllAnswerValid ? Color.primaryDefault : Color.grayscaleDark3)
           : Color.primaryDefault)
         .contentShape(Rectangle())
     }

--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkViewModel.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkViewModel.swift
@@ -26,7 +26,7 @@ final class EditValueTalkViewModel {
   var cardViewModels: [EditValueTalkCardViewModel] = []
   var isEditing: Bool = false
   var isEdited: Bool {
-    initialValueTalks != valueTalks
+    initialValueTalks.map { $0.answer } != valueTalks.map { $0.answer }
   }
   var showValueTalkExitAlert: Bool = false
   var shouldPopBack: Bool = false

--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkViewModel.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkViewModel.swift
@@ -28,6 +28,9 @@ final class EditValueTalkViewModel {
   var isEdited: Bool {
     initialValueTalks.map { $0.answer } != valueTalks.map { $0.answer }
   }
+  var isAllAnswerValid: Bool {
+    cardViewModels.allSatisfy { $0.isAnswerValid }
+  }
   var showValueTalkExitAlert: Bool = false
   var shouldPopBack: Bool = false
   
@@ -93,7 +96,7 @@ final class EditValueTalkViewModel {
           valueTalks[index] = cardViewModel.model
         }
       }
-      if isEdited {
+      if isAllAnswerValid {
         await updateProfileValueTalks()
       }
     } else {

--- a/Presentation/Feature/EditValueTalk/Sources/EditViewTalkCardViewModel.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditViewTalkCardViewModel.swift
@@ -18,6 +18,11 @@ final class EditValueTalkCardViewModel: Equatable {
     lhs.model == rhs.model
   }
   
+  enum Constants {
+    static let minAnswerLength: Int = 30
+    static let maxAnswerLength: Int = 300
+  }
+  
   enum Action {
     case didUpdateAnswer(String)
     case didUpdateSummary(String)
@@ -37,6 +42,10 @@ final class EditValueTalkCardViewModel: Equatable {
   var localSummary: String
   var currentGuideText: String {
     model.guides[guideTextIndex]
+  }
+  var isAnswerValid: Bool {
+    model.answer.count >= Constants.minAnswerLength
+    && model.answer.count <= Constants.maxAnswerLength
   }
   
   private(set) var editingState: EditingState = .viewing
@@ -62,7 +71,8 @@ final class EditValueTalkCardViewModel: Equatable {
   func handleAction(_ action: Action) {
     switch action {
     case let .didUpdateAnswer(answer):
-      model.answer = answer
+      let limitedAnswer = String(answer.prefix(Constants.maxAnswerLength))
+      model.answer = limitedAnswer
       onModelUpdate(model)
       
     case let .didUpdateSummary(summary):

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerView.swift
@@ -61,15 +61,15 @@ struct CreateProfileContainerView: View {
           .opacity(viewModel.currentStep == .basicInfo ? 1 : 0)
           .disabled(viewModel.currentStep != .basicInfo)
         
-        valueTalkView
-          .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
-          .opacity(viewModel.currentStep == .valueTalk ? 1 : 0)
-          .disabled(viewModel.currentStep != .valueTalk)
-        
         valuePickView
           .transition(.move(edge: .trailing))
           .opacity(viewModel.currentStep == .valuePick ? 1 : 0)
           .disabled(viewModel.currentStep != .valuePick)
+        
+        valueTalkView
+          .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+          .opacity(viewModel.currentStep == .valueTalk ? 1 : 0)
+          .disabled(viewModel.currentStep != .valueTalk)
       }
       .animation(.easeInOut, value: viewModel.currentStep)
     }
@@ -102,12 +102,19 @@ struct CreateProfileContainerView: View {
   }
   
   private var valueTalkView: some View {
-    ValueTalkView(
-      profileCreator: viewModel.profileCreator,
-      initialValueTalks: viewModel.valueTalks,
-      didTapBottomButton: { viewModel.handleAction(.didTapBottomButton) }
-    )
-    .id(valueTalk)
+    Group {
+      if let valueTalkViewModel = viewModel.valueTalkViewModel {
+        ValueTalkView(
+          viewModel: valueTalkViewModel,
+          didTapBottomButton: {
+            viewModel.handleAction(.didTapBottomButton)
+          }
+        )
+        .id(valueTalk)
+      } else {
+        EmptyView()
+      }
+    }
   }
   
   private var valuePickView: some View {

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerViewModel.swift
@@ -26,6 +26,7 @@ final class CreateProfileContainerViewModel {
   
   var currentStep: CreateProfileStep = .basicInfo
   var valuePickViewModel: ValuePickViewModel?
+  var valueTalkViewModel: ValueTalkViewModel?
   
   let profileCreator = ProfileCreator()
   let checkNicknameUseCase: CheckNicknameUseCase
@@ -83,6 +84,11 @@ final class CreateProfileContainerViewModel {
       self.valuePickViewModel = ValuePickViewModel(
         profileCreator: profileCreator,
         initialValuePicks: valuePicks
+      )
+      
+      self.valueTalkViewModel = ValueTalkViewModel(
+        profileCreator: profileCreator,
+        initialValueTalks: valueTalks
       )
 
       error = nil

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkCard.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkCard.swift
@@ -10,6 +10,11 @@ import Entities
 import SwiftUI
 
 struct ValueTalkCard: View {
+  private enum Constants {
+    static let minAnswerCount: Int = 30
+    static let maxAnswerCount: Int = 300
+  }
+  
   private var focusState: FocusState<ValueTalkView.Field?>.Binding
   @Binding private var viewModel: ValueTalkCardViewModel
 
@@ -87,8 +92,12 @@ struct ValueTalkCard: View {
       }
       .focused(focusState, equals: .valueTalkEditor(viewModel.model.id))
       
-      TextCountIndicator(count: .constant(viewModel.localAnswer.count), maxCount: 300)
-        .opacity(!viewModel.localAnswer.isEmpty || focusState.wrappedValue == .valueTalkEditor(viewModel.model.id) ? 1 : 0)
+      TextCountIndicator(
+        count: .constant(viewModel.localAnswer.count),
+        minCount: Constants.minAnswerCount,
+        maxCount: Constants.maxAnswerCount
+      )
+      .opacity(!viewModel.localAnswer.isEmpty || focusState.wrappedValue == .valueTalkEditor(viewModel.model.id) ? 1 : 0)
     }
     .padding(.horizontal, 16)
     .padding(.vertical, 10) // 폰트 내 lineHeight로 인해서 상단이 패딩이 더 커보이는 것 보졍

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkView.swift
@@ -7,7 +7,6 @@
 
 import DesignSystem
 import Entities
-import Router
 import SwiftUI
 import UseCases
 
@@ -17,21 +16,14 @@ struct ValueTalkView: View {
   }
   
   @Bindable var viewModel: ValueTalkViewModel
-  @Environment(Router.self) private var router: Router
   @FocusState private var focusField: Field?
   var didTapBottomButton: () -> Void
 
   init(
-    profileCreator: ProfileCreator,
-    initialValueTalks: [ValueTalkModel],
+    viewModel: ValueTalkViewModel,
     didTapBottomButton: @escaping () -> Void
   ) {
-    _viewModel = .init(
-      wrappedValue: .init(
-        profileCreator: profileCreator,
-        initialValueTalks: initialValueTalks
-      )
-    )
+    self.viewModel = viewModel
     self.didTapBottomButton = didTapBottomButton
   }
 

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkViewModel.swift
@@ -13,6 +13,10 @@ import UseCases
 @MainActor
 @Observable
 final class ValueTalkViewModel {
+  private enum Constants {
+    static let minAnswerCount: Int = 30
+  }
+  
   enum Action {
     case didTapBottomButton
     case updateAnswer(index: Int, answer: String)
@@ -55,7 +59,10 @@ final class ValueTalkViewModel {
       valueTalks[cardViewModel.index].answer = cardViewModel.localAnswer
     }
     
-    let isValid = valueTalks.allSatisfy( { $0.answer?.isEmpty == false })
+    let isValid = valueTalks.allSatisfy { valueTalk in
+      guard let answer = valueTalk.answer, !answer.isEmpty else { return false }
+      return answer.count >= Constants.minAnswerCount
+    }
     print("📌 isValid: \(isValid)")
     if isValid {
       profileCreator.updateValueTalks(valueTalks)

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkViewModel.swift
@@ -56,6 +56,7 @@ final class ValueTalkViewModel {
     }
     
     let isValid = valueTalks.allSatisfy( { $0.answer?.isEmpty == false })
+    print("📌 isValid: \(isValid)")
     if isValid {
       profileCreator.updateValueTalks(valueTalks)
       profileCreator.isValueTalksValid(isValid)


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1048](https://yapp25app3.atlassian.net/browse/PC-1048)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 가입/수정 시 ValueTalk의 TextEditor 작성 시 최소 글자 제한 관련 TextIndicator UI 구현
  - 가입 시 ValueTalk 관련 ViewModel 버그 수정
    - View 리렌더링 시 ViewModel이 초기화되는 버그를 수정
  - 수정 시 ValueTalk의 isEdited 조건을 수정
    - AI Summary가 다를 수 있기 때문
  - 최소/최대 글자 제한 로직 추가
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 최소 글자 사용자 피드백 | 최소/최대 글자 제한 로직 추가 |
| :--: | :--: |
| ![Jul-28-2025 21-34-01](https://github.com/user-attachments/assets/1de50ca3-8dc4-4a8d-a033-75a326ab56e5) |  ![Jul-30-2025 20-44-21](https://github.com/user-attachments/assets/47a8587e-974f-466c-a7b7-d521076dfe04) |

[PC-1048]: https://yapp25app3.atlassian.net/browse/PC-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ