### PR TITLE
[PC-1059] Fix: 가치관 Talk의 TextEditor의 동적 높이 조절 이슈를 개선합니다.

### DIFF
--- a/Presentation/Feature/EditValueTalk/Sources/EditValueTalkCard.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditValueTalkCard.swift
@@ -90,12 +90,17 @@ struct EditValueTalkCard: View {
       .foregroundStyle(Color.grayscaleDark1)
   }
   
+  
+  private var answerTextBinding: Binding<String> {
+    Binding(
+      get: { viewModel.answerText },
+      set: { viewModel.handleAction(.didUpdateAnswer($0)) }
+    )
+  }
+  
   private var answer: some View {
     VStack(spacing: 16) {
-      TextEditor(text: Binding(
-        get: { viewModel.model.answer },
-        set: { viewModel.handleAction(.didUpdateAnswer($0)) }
-      ))
+      TextEditor(text: answerTextBinding)
       .frame(maxWidth: .infinity, minHeight: Constants.valueTalkMinHeight, maxHeight: .infinity)
       .fixedSize(horizontal: false, vertical: true)
       .pretendard(.body_M_M)
@@ -117,6 +122,10 @@ struct EditValueTalkCard: View {
         if isEditing {
           focusState.wrappedValue = .answerEditor(id)
         }
+      }
+      .task {
+        try? await Task.sleep(for: .milliseconds(50))
+        viewModel.handleAction(.initializeTextEditorLayout)
       }
       
       if isEditing {

--- a/Presentation/Feature/EditValueTalk/Sources/EditViewTalkCardViewModel.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditViewTalkCardViewModel.swift
@@ -22,6 +22,7 @@ final class EditValueTalkCardViewModel: Equatable {
   }
   
   enum Action {
+    case initializeTextEditorLayout
     case didUpdateAnswer(String)
     case didUpdateSummary(String)
     case didTapSummaryButton
@@ -50,6 +51,7 @@ final class EditValueTalkCardViewModel: Equatable {
   
   private(set) var editingState: EditingState = .viewing
   private(set) var guideTextIndex: Int = 0
+  private(set) var answerText: String = ""
   private var cancellables: [AnyCancellable] = []
   
   let onModelUpdate: (ProfileValueTalkModel) -> Void
@@ -73,9 +75,12 @@ final class EditValueTalkCardViewModel: Equatable {
   
   func handleAction(_ action: Action) {
     switch action {
+      /// TextEditor 높이 계산을 위한 초기 텍스트 설정 (SwiftUI 렌더링 타이밍 이슈 해결)
+    case .initializeTextEditorLayout:
+      self.answerText = model.answer
+      
     case let .didUpdateAnswer(answer):
-      let limitedAnswer = String(answer.prefix(Constants.maxAnswerLength))
-      model.answer = limitedAnswer
+      syncAnswerTextModel(answer)
       onModelUpdate(model)
       
     case let .didUpdateSummary(summary):
@@ -95,6 +100,12 @@ final class EditValueTalkCardViewModel: Equatable {
     localSummary = summary
     model.summary = summary
     editingState = .viewing
+  }
+  
+  func syncAnswerTextModel(_ answer: String) {
+    let limitedAnswer = String(answer.prefix(Constants.maxAnswerLength))
+    model.answer = limitedAnswer
+    answerText = limitedAnswer
   }
   
   func startGeneratingAISummary() {

--- a/Presentation/Feature/EditValueTalk/Sources/EditViewTalkCardViewModel.swift
+++ b/Presentation/Feature/EditValueTalk/Sources/EditViewTalkCardViewModel.swift
@@ -8,8 +8,6 @@
 import Combine
 import Entities
 import Foundation
-import SwiftUI
-import Observation
 
 @MainActor
 @Observable


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1059](https://yapp25app3.atlassian.net/browse/PC-1059)

## 👷🏼‍♂️ 변경 사항
- **TextEditor 동적 높이 계산 이슈 해결**
  - `answerText` 바인딩 분리로 데이터 일관성 확보
  - SwiftUI 렌더링 타이밍 이슈로 인한 높이 미적용 문제 해결
  - `.task` + delay를 통한 초기 높이 계산 최적화

- **코드 구조 개선**
  - 답변 텍스트 동기화 로직을 `syncAnswerTextModel` 함수로 분리
  - 액션 네이밍을 `onAppear` → `initializeTextEditorLayout`으로 명확화
  - 불필요한 import 제거 및 코드 정리

- **UI 일관성 향상**
  - TextEditor와 placeholder 표시 조건을 `answerText` 기준으로 통일
  - TextCountIndicator는 실제 모델 데이터(`model.answer.count`) 기준 유지

## 💬 참고 사항
- SwiftUI TextEditor의 렌더링 타이밍 특성상 `.task`에서 50ms delay 후 초기화 로직 실행
- `model.answer`와 `answerText` 동기화를 통해 데이터 불일치 문제 해결
- 높이 계산을 위한 워크어라운드이므로 주석으로 목적 명시


## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
| ![noanima](https://github.com/user-attachments/assets/dcbcfc10-c0b2-42d3-99bb-fcba0f6fe2dc) |