### PR TITLE
[PC-1072] Build: Debug/Release 스킴 분리

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/AppContants.swift
+++ b/Tuist/ProjectDescriptionHelpers/AppContants.swift
@@ -6,14 +6,37 @@
 //
 
 import ProjectDescription
+import Foundation
 
 public enum AppConstants {
+  // MARK: - Signing & Certificate
+  public static let developmentTeam: String = "$(DEVELOPMENT_TEAM)"
+  public static let provisioningProfile: String = "$(PROVISIONING_PROFILE)"
+  public static let codeSignStyle: String = "$(CODE_SIGN_STYLE)"
+ 
+  // MARK: - 실제 앱스토어 릴리즈 전용
   public static let appName: String = "Piece-iOS"
-  public static let organizationName: String = "puzzly"
+  
   public static let bundleId: String = "com.puzzly.piece"
-  public static let bundleDisplayName: Plist.Value = "피스"
-  public static let version: Plist.Value = "1.0.1"
-  public static let build: Plist.Value = "1"
+  
+  public static let bundleDisplayNameString: String = "$(BUNDLE_DISPLAY_NAME)"
+  public static let bundleDisplayName: Plist.Value = "\(bundleDisplayNameString)"
+  
+  // TODO: - 추후 카카오 디벨로퍼 멀티앱 승인 후 멀티 BundleId가 가능해지고, 타겟 분리가 가능해질 때 쓸 것
+  // MARK: - 내부 테스트 전용
+//  public static let devAppName: String = "Piece-iOS-Dev"
+//  public static let devBundleId: String = "com.puzzly.piece.dev"
+//  public static let devBundleDisplayName: Plist.Value = "피스-Dev"
+  
+  // MARK: - [내부 테스트/실제 앱스토어 릴리즈] 공통
+  public static let organizationName: String = "puzzly"
+  
+  public static let versionString: String = "$(APP_VERSION)"
+  public static let version: Plist.Value = "\(versionString)"
+  
+  public static let buildString: String = "$(APP_BUILD)"
+  public static let build: Plist.Value = "\(buildString)"
+  
   public static let destinations: Set<Destination> = [.iPhone]
   public static let deploymentTargets: DeploymentTargets = .iOS("17.0")
 }

--- a/Tuist/ProjectDescriptionHelpers/AppEnvironment.swift
+++ b/Tuist/ProjectDescriptionHelpers/AppEnvironment.swift
@@ -7,11 +7,11 @@
 
 import ProjectDescription
 //
-//public enum AppEnvironment: String {
-//  case dev
-//  case prod
-//  
-//  public var configurationName: ConfigurationName {
-//    return ConfigurationName.configuration(self.rawValue)
-//  }
-//}
+public enum AppEnvironment: String {
+  case Debug /// 개발 서버 스킴
+  case Release /// 운영 서버 스킴
+  
+  public var configurationName: ConfigurationName {
+    return ConfigurationName.configuration(self.rawValue)
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Configuration/Configuration+configuration.swift
+++ b/Tuist/ProjectDescriptionHelpers/Configuration/Configuration+configuration.swift
@@ -6,19 +6,28 @@
 //
 
 import ProjectDescription
-//
-//// TODO: - xcconfig 경로 추가
-//extension Configuration {
-//  public static func configuration(environment: AppEnvironment) -> Self {
-//    switch environment {
-//    case .dev:
-//      return .debug(
-//        name: environment.configurationName
-//      )
-//    case .prod:
-//      return .release(
-//        name: environment.configurationName
-//      )
-//    }
-//  }
-//}
+
+extension Configuration {
+  public static func configuration(environment: AppEnvironment) -> Self {
+    switch environment {
+    case .Debug:
+      return .debug(
+        name: environment.configurationName,
+        settings: [
+          "CODE_SIGN_IDENTITY": SettingValue.string("Apple Development"),
+          "PROVISIONING_PROFILE_SPECIFIER": SettingValue.string(AppConstants.provisioningProfile),
+        ],
+        xcconfig: .relativeToRoot("Debug.xcconfig")
+      )
+    case .Release:
+      return .release(
+        name: environment.configurationName,
+        settings: [
+          "CODE_SIGN_IDENTITY": SettingValue.string("Apple Distribution"),
+          "PROVISIONING_PROFILE_SPECIFIER": SettingValue.string(AppConstants.provisioningProfile),
+        ],
+        xcconfig: .relativeToRoot("Release.xcconfig")
+      )
+    }
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
@@ -14,16 +14,62 @@ extension Project {
     packages: [Package] = []
   ) -> Project {
     let name = AppConstants.appName
-    let target = Target.target(
+    
+    let prodTarget = Target.makeAppTarget(
       name: AppConstants.appName,
+      bundleId: AppConstants.bundleId,
+      dependencies: dependencies
+    )
+    
+    // TODO: - 추후 타겟 분리하면 씀
+//    let devTarget = Target.makeAppTarget(
+//      name: AppConstants.devAppName,
+//      bundleId: AppConstants.devBundleId,
+//      bundleDisplayName: AppConstants.devBundleDisplayName,
+//      dependencies: dependencies
+//    )
+    
+    return Project(
+      name: name,
+      organizationName: AppConstants.organizationName,
+      options: .options(
+        automaticSchemesOptions: .disabled,
+        developmentRegion: "kor"
+      ),
+      packages: packages,
+      settings: .settings(),
+      targets: [
+        prodTarget,
+        // TODO: - 추후 타겟 분리하면 씀
+//        devTarget
+      ],
+      schemes: [
+        .makeDevScheme(),
+        .makeReleaseScheme(),
+      ]
+    )
+  }
+}
+
+extension Target {
+  static func makeAppTarget(
+    name: String,
+    bundleId: String,
+    dependencies: [TargetDependency]
+  ) -> Target {
+    return Target.target(
+      name: name,
       destinations: AppConstants.destinations,
       product: .app,
-      bundleId: AppConstants.bundleId,
+      bundleId: bundleId,
       deploymentTargets: AppConstants.deploymentTargets,
       infoPlist: .extendingDefault(
         with: [
           "UIUserInterfaceStyle": "Light",
           "UILaunchStoryboardName": "LaunchScreen",
+          "UISupportedInterfaceOrientations": [
+            "UIInterfaceOrientationPortrait"
+          ],
           "UIBackgroundModes": ["remote-notification"],
           "NSCameraUsageDescription": "프로필 생성 시 사진 첨부를 위해 카메라 접근 권한이 필요합니다.",
           "NSPhotoLibraryUsageDescription": "프로필 생성 시 사진 첨부를 위해 앨범 접근 권한이 필요합니다.",
@@ -146,43 +192,19 @@ extension Project {
       dependencies: dependencies,
       settings: .settings(
         base: [
-          "OTHER_LDFLAGS": ["-ObjC"]
+          "OTHER_LDFLAGS": ["-ObjC"],
+          "CODE_SIGN_STYLE": SettingValue.string(AppConstants.codeSignStyle),
+          "DEVELOPMENT_TEAM": SettingValue.string(AppConstants.developmentTeam),
+          "MARKETING_VERSION": SettingValue.string(AppConstants.versionString),
+          "CURRENT_PROJECT_VERSION": SettingValue.string(AppConstants.buildString),
         ],
         configurations: [
-          .debug(name: "Debug", xcconfig: .relativeToRoot("Debug.xcconfig")),
-          .release(name: "Release", xcconfig: .relativeToRoot("Release.xcconfig"))
+          .configuration(environment: .Debug),
+          .configuration(environment: .Release),
         ]
-      )
-      //          .settings(
-      //        configurations: [
-      //          .configuration(environment: .dev),
-      //          .configuration(environment: .prod),
-      //        ]
-      //      )
-      ,
+      ),
       environmentVariables: [:],
       additionalFiles: []
-    )
-    
-    return Project(
-      name: name,
-      organizationName: AppConstants.organizationName,
-      options: .options(
-        automaticSchemesOptions: .disabled,
-        developmentRegion: "kor"
-      ),
-      packages: packages,
-      settings: .settings(),
-      //          .settings(configurations: [
-      //        .configuration(environment: .dev),
-      //        .configuration(environment: .prod),
-      //      ]),
-      targets: [target],
-      schemes: [
-        .makeScheme(),
-        //        .makeScheme(environment: .dev),
-        //        .makeScheme(environment: .prod),
-      ]
     )
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/Scheme/Scheme+makeScheme.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme/Scheme+makeScheme.swift
@@ -8,14 +8,27 @@
 import ProjectDescription
 
 extension Scheme {
-  public static func makeScheme(/*environment: AppEnvironment*/) -> Scheme {
+//   MARK: - 운영 서버
+  public static func makeReleaseScheme(/*environment: AppEnvironment*/) -> Scheme {
     return .scheme(
-      name: "\(AppConstants.appName)"/*-\(environment.rawValue)*/,
+      name: "\(AppConstants.appName)-Release",
       buildAction: .buildAction(targets: ["\(AppConstants.appName)"]),
-      runAction: .runAction(configuration: "Debug"),// environment.configurationName),
-      archiveAction: .archiveAction(configuration: "Release"), //environment.configurationName),
-      profileAction: .profileAction(configuration: "Release"), //environment.configurationName),
-      analyzeAction: .analyzeAction(configuration: "Debug") //environment.configurationName)
+      runAction: .runAction(configuration: "Release"),
+      archiveAction: .archiveAction(configuration: "Release"),
+      profileAction: .profileAction(configuration: "Release"),
+      analyzeAction: .analyzeAction(configuration: "Release")
+    )
+  }
+  
+  // MARK: - 개발 서버
+  public static func makeDevScheme() -> Scheme {
+    return .scheme(
+      name: "\(AppConstants.appName)-Debug"/*"\(AppConstants.devAppName)"*/,
+      buildAction: .buildAction(targets: ["\(AppConstants.appName)"]),
+      runAction: .runAction(configuration: "Debug"),
+      archiveAction: .archiveAction(configuration: "Debug"),
+      profileAction: .profileAction(configuration: "Debug"),
+      analyzeAction: .analyzeAction(configuration: "Debug")
     )
   }
 }


### PR DESCRIPTION
- 민감한 정보는 config 파일로 관리

## 🏷️ 티켓 번호
[PC-1072](https://yapp25app3.atlassian.net/browse/PC-1072)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - Tuist 설정을 통해 Debug/Release 스킴을 분리
  - Debug/Config 파일을 통해 민감한 정보를 관리
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용
- 추후 카카오디벨로퍼에서 멀티 BundleID 지원 시 운영/개발 앱의 타겟 분리가 가능할 것 같음.
- 지금은 불가능

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1072]: https://yapp25app3.atlassian.net/browse/PC-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ