### PR TITLE
[PC-1057] Fix: 설정 화면 시스템 설정 권한 로직 개선

### DIFF
--- a/Data/Repository/Sources/SignUp/BlockContactsRepository.swift
+++ b/Data/Repository/Sources/SignUp/BlockContactsRepository.swift
@@ -10,6 +10,7 @@ import DTO
 import PCNetwork
 import Entities
 import RepositoryInterfaces
+import LocalStorage
 
 public final class BlockContactsRepository: BlockContactsRepositoryInterface {
   private let networkService: NetworkService
@@ -22,6 +23,10 @@ public final class BlockContactsRepository: BlockContactsRepositoryInterface {
     let requestDto = phoneNumbers.toDTO()
     let endpoint = BlockEndpoint.postBlockContacts(body: requestDto)
     let responseDTO: VoidResponseDTO = try await networkService.request(endpoint: endpoint)
+    
+    let now = Date()
+    let utcToKst = now.addingTimeInterval(9 * 60 * 60) // UTC를 KST로 변환
+    PCUserDefaultsService.shared.setLatestSyncDate(utcToKst)
     return responseDTO.toDomain()
   }
 }

--- a/Domain/UseCases/Sources/Permission/RequestContactsPermissionUseCase.swift
+++ b/Domain/UseCases/Sources/Permission/RequestContactsPermissionUseCase.swift
@@ -6,7 +6,6 @@
 //
 
 import Contacts
-import LocalStorage
 
 public protocol RequestContactsPermissionUseCase {
   func execute() async throws -> Bool
@@ -31,15 +30,8 @@ final class RequestContactsPermissionUseCaseImpl: RequestContactsPermissionUseCa
     switch authorizationStatus {
     // 아직 권한 요청을 한 적이 없는 상태이므로 권한 요청 팝업 및 사용자의 응답 결과를 반환
     case .notDetermined:
-      if try await contactStore.requestAccess(for: .contacts) {
-        let now = Date()
-        let utcToKst = now.addingTimeInterval(9 * 60 * 60) // UTC를 KST로 변환
-        PCUserDefaultsService.shared.setLatestSyncDate(utcToKst)
-        return true
-      } else {
-        return false
-      }
-
+      return try await contactStore.requestAccess(for: .contacts)
+      
     // 이미 권한이 허용된 상태 (일부 허용 포함)
     case .authorized, .limited:
       return true

--- a/Domain/UseCases/Sources/SignUp/FetchContactsUseCase.swift
+++ b/Domain/UseCases/Sources/SignUp/FetchContactsUseCase.swift
@@ -21,34 +21,15 @@ public final class FetchContactsUseCaseImpl: FetchContactsUseCase {
   }
   
   public func execute() async throws -> [String] {
-    var authorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
-    
-    if authorizationStatus == .notDetermined {
-      let granted = try await contactStore.requestAccess(for: .contacts)
-      authorizationStatus = granted ? .authorized : .denied
-    }
-    
-    if #available(iOS 18.0, *) {
-      guard authorizationStatus == .authorized || authorizationStatus == .limited else {
-        return []
-      }
-    } else {
-      guard authorizationStatus == .authorized else {
-        return []
-      }
-    }
-    
-    var phoneNumbers: [String] = []
+    var allPhoneNumbers: [String] = []
     let keysToFetch = [CNContactPhoneNumbersKey as CNKeyDescriptor]
     let request = CNContactFetchRequest(keysToFetch: keysToFetch)
     
     try contactStore.enumerateContacts(with: request) { contact, _ in
-      let numbers = contact.phoneNumbers.map {
-        $0.value.stringValue
-      }
-      phoneNumbers.append(contentsOf: numbers)
+      let contactPhoneNumbers = contact.phoneNumbers.map { $0.value.stringValue }
+      allPhoneNumbers.append(contentsOf: contactPhoneNumbers)
     }
     
-    return phoneNumbers
+    return allPhoneNumbers
   }
 }

--- a/Domain/UseCases/Sources/SignUp/FetchContactsUseCase.swift
+++ b/Domain/UseCases/Sources/SignUp/FetchContactsUseCase.swift
@@ -21,10 +21,11 @@ public final class FetchContactsUseCaseImpl: FetchContactsUseCase {
   }
   
   public func execute() async throws -> [String] {
-    let authorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
+    var authorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
     
     if authorizationStatus == .notDetermined {
-      _ = try await contactStore.requestAccess(for: .contacts)
+      let granted = try await contactStore.requestAccess(for: .contacts)
+      authorizationStatus = granted ? .authorized : .denied
     }
     
     if #available(iOS 18.0, *) {

--- a/Presentation/Feature/Settings/Sources/Items/SettingsSynchronizeContactView.swift
+++ b/Presentation/Feature/Settings/Sources/Items/SettingsSynchronizeContactView.swift
@@ -27,7 +27,7 @@ struct SettingsSynchronizeContactView: View {
         }
         VStack(spacing: 4) {
           HStack(spacing: 0) {
-            Text("내 연락처 목록을 즉시 업데이트합니다.\n연락처에 새로 추가된 지인을 차단할 수 있어요.")
+            Text("나의 연락처 목록이 즉시 업데이트돼요.\n연락처에 새로 추가된 지인을 차단할 수 있어요.")
               .pretendard(.caption_M_M)
               .foregroundStyle(Color.grayscaleDark3)
             Spacer()

--- a/Presentation/Feature/Settings/Sources/Items/SettingsToggleView.swift
+++ b/Presentation/Feature/Settings/Sources/Items/SettingsToggleView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct SettingsToggleView: View {
   let title: String
   @Binding var isOn: Bool
-  let onToggle: ((Bool) -> Void)?
   
   var body: some View {
     HStack(alignment: .center, spacing: 0) {
@@ -20,9 +19,6 @@ struct SettingsToggleView: View {
         .padding(.vertical, 16)
       Spacer()
       PCToggle(isOn: $isOn)
-        .onChange(of: isOn) { _, newValue in
-          onToggle?(newValue)
-        }
     }
   }
 }

--- a/Presentation/Feature/Settings/Sources/Sections/SettingsNotificationSettingSectionView.swift
+++ b/Presentation/Feature/Settings/Sources/Sections/SettingsNotificationSettingSectionView.swift
@@ -11,15 +11,13 @@ struct SettingsNotificationSettingSectionView: View {
   let title: String
   @Binding var isMatchingNotificationOn: Bool
   @Binding var isPushNotificationOn: Bool
-  let matchingNotificationToggled: ((Bool) -> Void)?
-  let pushNotificationToggled: ((Bool) -> Void)?
-  
+
   var body: some View {
     VStack(spacing: 8) {
       SettingsSectionHeaderTitleView(title: title)
       VStack(spacing: 0) {
-        SettingsToggleView(title: "매칭 알림", isOn: $isMatchingNotificationOn, onToggle: matchingNotificationToggled )
-        SettingsToggleView(title: "푸쉬 알림", isOn: $isPushNotificationOn, onToggle: pushNotificationToggled)
+        SettingsToggleView(title: "매칭 알림", isOn: $isMatchingNotificationOn)
+        SettingsToggleView(title: "푸쉬 알림", isOn: $isPushNotificationOn)
       }
     }
   }

--- a/Presentation/Feature/Settings/Sources/Sections/SettingsSystemSettingSectionView.swift
+++ b/Presentation/Feature/Settings/Sources/Sections/SettingsSystemSettingSectionView.swift
@@ -13,14 +13,13 @@ struct SettingsSystemSettingSectionView: View {
   @Binding var isBlockingFriends: Bool
   @Binding var date: String
   @Binding var isSyncingContact: Bool
-  let blockContactsToggled: ((Bool) -> Void)?
   let didTapRefreshButton: () -> Void
 
   var body: some View {
     VStack(spacing: 8) {
       SettingsSectionHeaderTitleView(title: title)
       VStack(spacing: 0) {
-        SettingsToggleView(title: "지인 차단", isOn: $isBlockingFriends, onToggle: blockContactsToggled)
+        SettingsToggleView(title: "아는 사람 차단", isOn: $isBlockingFriends)
         if isBlockingFriends {
           SettingsSynchronizeContactView(
             title: "연락처 동기화",

--- a/Presentation/Feature/Settings/Sources/SettingsView.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsView.swift
@@ -82,6 +82,19 @@ struct SettingsView: View {
       .padding(.bottom, 89) // 탭바 높이 만큼 패딩
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .alert(
+      "알림 권한이 필요합니다",
+      isPresented: $viewModel.showPushNotificationAlert
+    ) {
+      Button("취소", role: .cancel) {
+        // TODO: - 취소 누르면 PUT으로 푸시알림 끄기
+      }
+      Button("설정") {
+        viewModel.handleAction(.openSettings)
+      }
+    } message: {
+      Text("푸쉬 알림을 받으려면 설정에서 알림을 허용해주세요.")
+    }
     .pcAlert(isPresented: $viewModel.showLogoutAlert) {
       AlertView(
         title: {

--- a/Presentation/Feature/Settings/Sources/SettingsView.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsView.swift
@@ -84,16 +84,42 @@ struct SettingsView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .alert(
       "알림 권한이 필요합니다",
-      isPresented: $viewModel.showPushNotificationAlert
+      isPresented: $viewModel.showMatchNotificationAlert
     ) {
-      Button("취소", role: .cancel) {
-        // TODO: - 취소 누르면 PUT으로 푸시알림 끄기
-      }
       Button("설정") {
         viewModel.handleAction(.openSettings)
       }
+      Button("취소") {
+        viewModel.handleAction(.matchingNotificationToggled(false))
+      }
     } message: {
-      Text("푸쉬 알림을 받으려면 설정에서 알림을 허용해주세요.")
+      Text("\"매칭 알림\" 기능을 사용하려면\n[설정]-[피스]-[알림]을 허용해주세요.")
+    }
+    .alert(
+      "알림 권한이 필요합니다",
+      isPresented: $viewModel.showNotificationAlert
+    ) {
+      Button("설정") {
+        viewModel.handleAction(.openSettings)
+      }
+      Button("취소") {
+        viewModel.handleAction(.pushNotificationToggled(false))
+      }
+    } message: {
+      Text("\"푸쉬 알림\" 기능을 사용하려면\n[설정]-[피스]-[알림]을 허용해주세요.")
+    }
+    .alert(
+      "연락처 접근 권한이 필요합니다",
+      isPresented: $viewModel.showAcquaintanceBlockAlert
+    ) {
+      Button("설정") {
+        viewModel.handleAction(.openSettings)
+      }
+      Button("취소") {
+        viewModel.handleAction(.blockContactsToggled(false))
+      }
+    } message: {
+      Text("\"아는 사람 차단\" 기능을 사용하려면\n[설정]-[피스]-[연락처 접근]을 허용해주세요.")
     }
     .pcAlert(isPresented: $viewModel.showLogoutAlert) {
       AlertView(
@@ -123,18 +149,24 @@ struct SettingsView: View {
     case .notification:
       SettingsNotificationSettingSectionView(
         title: section.title,
-        isMatchingNotificationOn: $viewModel.isMatchingNotificationOn,
-        isPushNotificationOn: $viewModel.isPushNotificationEnabled,
-        matchingNotificationToggled: { isEnabled in viewModel.handleAction(.matchingNotificationToggled(isEnabled)) },
-        pushNotificationToggled: { isEnabled in viewModel.handleAction(.pushNotificationToggled(isEnabled)) }
+        isMatchingNotificationOn: Binding(
+          get: { viewModel.isMatchNotificationEnable },
+          set: { isEnable in viewModel.handleAction(.matchingNotificationToggled(isEnable)) }
+        ),
+        isPushNotificationOn: Binding(
+          get: { viewModel.isNotificationEnabled },
+          set: { isEnable in viewModel.handleAction(.pushNotificationToggled(isEnable)) }
+        )
       )
     case .system:
       SettingsSystemSettingSectionView(
         title: section.title,
-        isBlockingFriends: $viewModel.isBlockContactsEnabled,
+        isBlockingFriends: Binding(
+          get: { viewModel.isAcquaintanceBlockEnabled },
+          set: { isEnable in viewModel.handleAction(.blockContactsToggled(isEnable))}
+        ),
         date: .init(projectedValue: .constant(viewModel.updatedDateString)),
         isSyncingContact: $viewModel.isSyncingContact,
-        blockContactsToggled: { isEnabled in viewModel.handleAction(.blockContactsToggled(isEnabled)) },
         didTapRefreshButton: { viewModel.handleAction(.synchronizeContactsButtonTapped) }
       )
     case .ask:

--- a/Presentation/Feature/Settings/Sources/SettingsViewModel.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsViewModel.swift
@@ -26,10 +26,12 @@ final class SettingsViewModel {
     case confirmLogoutButton
     case withdrawButtonTapped
     case clearDestination
+    case openSettings
   }
   
   var sections = [SettingSection]()
   var showLogoutAlert: Bool = false
+  var showPushNotificationAlert: Bool = false
   var isMatchingNotificationOn = false
   var isPushNotificationEnabled = false
   var isBlockContactsEnabled: Bool = false
@@ -148,6 +150,8 @@ final class SettingsViewModel {
       
     case .clearDestination:
       destination = nil
+    case .openSettings:
+      openSettings()
     }
   }
   
@@ -319,6 +323,16 @@ final class SettingsViewModel {
       _ = try await putSettingsBlockAcquaintanceUseCase.execute(isEnabled: isEnabled)
     } catch {
       print(error)
+    }
+  }
+  
+  private func openSettings() {
+    Task {
+      if let url = URL(string: UIApplication.openSettingsURLString) {
+        await MainActor.run {
+          UIApplication.shared.open(url)
+        }
+      }
     }
   }
   


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1057](https://yapp25app3.atlassian.net/browse/PC-1057)

## 👷🏼‍♂️ 변경 사항
- 설정 화면 권한 로직 개선
  - 서버 상태와 디바이스 권한 상태 분리 관리
  - 권한 거부 시 설정 화면 이동 알림 추가
  - 연락처 권한 처리 로직을 적절한 UseCase로 이동 (SRP 적용)
  - 변수명 명확화 및 UI 텍스트 개선

## 💬 참고 사항
- 권한 관리 로직을 각 UseCase 책임에 맞게 분리
- 사용자 경험 개선을 위한 권한 안내 다이얼로그 추가


## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |