### PR TITLE
[PC-1146] Feature: 프로필 재심사 푸쉬 알림 지원 추가

### DIFF
--- a/Data/DTO/Sources/Notification/NotificationType+Decodable.swift
+++ b/Data/DTO/Sources/Notification/NotificationType+Decodable.swift
@@ -18,6 +18,10 @@ extension NotificationType: Decodable {
             self = .profileApproved
         case "PROFILE_REJECTED":
             self = .profileRejected
+        case "PROFILE_IMAGE_APPROVED":
+            self = .profileImageApproved
+        case "PROFILE_IMAGE_REJECTED":
+            self = .profileImageRejected
         case "MATCHING_NEW":
             self = .matchingNew
         case "MATCHING_ACCEPT":

--- a/Domain/Entities/Sources/Notification/NotificationType.swift
+++ b/Domain/Entities/Sources/Notification/NotificationType.swift
@@ -8,6 +8,8 @@
 public enum NotificationType {
   case profileApproved
   case profileRejected
+  case profileImageApproved
+  case profileImageRejected
   case matchingNew
   case matchingAccept
   case matchingSuccess

--- a/Presentation/Feature/NotificationList/Sources/NotificationItemModel.swift
+++ b/Presentation/Feature/NotificationList/Sources/NotificationItemModel.swift
@@ -22,6 +22,8 @@ struct NotificationItemModel: Identifiable {
     switch type {
     case .profileApproved: DesignSystemAsset.Icons.profileSolid24.swiftUIImage
     case .profileRejected: DesignSystemAsset.Icons.profileSolid24.swiftUIImage
+    case .profileImageApproved: DesignSystemAsset.Icons.profileSolid24.swiftUIImage
+    case .profileImageRejected: DesignSystemAsset.Icons.profileSolid24.swiftUIImage
     case .matchingNew: DesignSystemAsset.Icons.puzzleSolid24.swiftUIImage
     case .matchingAccept: DesignSystemAsset.Icons.puzzleSolid24.swiftUIImage
     case .matchingSuccess: DesignSystemAsset.Icons.heartPuzzle24.swiftUIImage
@@ -32,6 +34,8 @@ struct NotificationItemModel: Identifiable {
     switch type {
     case .profileApproved: .primaryDefault
     case .profileRejected: .subDefault
+    case .profileImageApproved: .primaryDefault
+    case .profileImageRejected: .subDefault
     case .matchingNew: .primaryDefault
     case .matchingAccept: .primaryDefault
     case .matchingSuccess: .primaryDefault


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1146](https://yapp25app3.atlassian.net/browse/PC-1146)

## 👷🏼‍♂️ 변경 사항
- PROFILE_IMAGE_APPROVED/REJECTED 알림 타입 지원
- 관련 NotificationType enum case 추가
- 관련 Model 변경 사항 추가
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1146]: https://yapp25app3.atlassian.net/browse/PC-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ