### PR TITLE
[PC-1158] FIx: 신고 화면 버그 수정 및 UX/UI 개선

### DIFF
--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -186,6 +186,7 @@ struct ReportUserView: View {
       buttonText: "다음",
       width: .maxWidth
     ) {
+      isEditingReportReason = false
       viewModel.handleAction(.didTapNextButton)
     }
   }

--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -43,6 +43,7 @@ struct ReportUserView: View {
           Spacer()
             .frame(height: keyboardHeight)
         }
+        .scrollDismissesKeyboard(.interactively)
         .scrollIndicators(.hidden)
         .onReceive(keyboardWillShowNotificationPublisher) { notification in
           handleKeyboardWillShow(notification, proxy: proxy)

--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -51,6 +51,8 @@ struct ReportUserView: View {
       }
       
       bottomButton
+        .padding(.horizontal, 20)
+        .padding(.bottom, 10)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .toolbar(.hidden)
@@ -116,13 +118,14 @@ struct ReportUserView: View {
         set: { viewModel.handleAction(.didSelectReportReason($0 ? reason : nil)) }
       ))
       .animation(.easeInOut, value: viewModel.selectedReportReason)
+      .padding(1)
       
       Text(reason.rawValue)
         .pretendard(.body_M_R)
         .foregroundStyle(.grayscaleBlack)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(.vertical, 12)
+    .padding(.vertical, 14)
   }
 
   private var reportReasonEditor: some View {

--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -124,16 +124,8 @@ struct ReportUserView: View {
   
   private func reportItem(reason: ReportReason) -> some View {
     HStack(alignment: .center, spacing: 12) {
-      PCRadio(isSelected: Binding(
-        get: { viewModel.selectedReportReason == reason },
-        set: {
-          if $0 {
-            viewModel.handleAction(.didSelectReportReason($0 ? reason : nil))
-            isEditingReportReason = false
-          }
-        }
-      ))
-      .padding(1)
+      PCRadio(isSelected: .constant(viewModel.selectedReportReason == reason))
+        .padding(1)
       
       Text(reason.rawValue)
         .pretendard(.body_M_R)
@@ -141,6 +133,11 @@ struct ReportUserView: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.vertical, 14)
+    .contentShape(Rectangle())
+    .onTapGesture {
+      viewModel.handleAction(.didSelectReportReason(reason))
+      isEditingReportReason = false
+    }
   }
 
   private var reportReasonEditor: some View {

--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -59,6 +59,9 @@ struct ReportUserView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .toolbar(.hidden)
+    .onTapGesture {
+      isEditingReportReason = false
+    }
     .pcAlert(isPresented: $viewModel.showBlockAlert) {
       AlertView(
         title: {
@@ -123,7 +126,12 @@ struct ReportUserView: View {
     HStack(alignment: .center, spacing: 12) {
       PCRadio(isSelected: Binding(
         get: { viewModel.selectedReportReason == reason },
-        set: { viewModel.handleAction(.didSelectReportReason($0 ? reason : nil)) }
+        set: {
+          if $0 {
+            viewModel.handleAction(.didSelectReportReason($0 ? reason : nil))
+            isEditingReportReason = false
+          }
+        }
       ))
       .padding(1)
       


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1158](https://yapp25app3.atlassian.net/browse/PC-1158)

## 👷🏼‍♂️ 변경 사항
기타탭 누르고 키보드 한 번 올라가면 안내려감,

- 왼쪽 라디오버튼 1px 짤렸던 이슈 해결
- 포커싱 해제 안됐던 이슈 해결
- 키보드 올라오면 다음버튼 bottom padding 없는 이슈 해결
- 터치영역이 라디오 버튼영역밖에 안되던 이슈 해결
- 라디오버튼 Selected 상태에서 다시 누르면 Default 상태로 바뀌는 이슈 해결
- 텍스트필드 포커싱 상태에서 적절한 영역만큼 스크롤이 안되던 이슈 해결
- 신고버튼 누를 때 키보드 숨김처리가 안되는 이슈 해결
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  ![Aug-21-2025 22-34-53](https://github.com/user-attachments/assets/bbc4c9c6-a2dd-49d1-b4df-62acb0bbb530)  |

[PC-1158]: https://yapp25app3.atlassian.net/browse/PC-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ