### PR TITLE
[PC-1201] Fix: 아는 사람 차단하기 화면 라우팅 버그를 수정합니다.

### DIFF
--- a/Presentation/Coordinator/Sources/Coordinator.swift
+++ b/Presentation/Coordinator/Sources/Coordinator.swift
@@ -214,7 +214,7 @@ public struct Coordinator {
         requestNotificationPermissionUseCase: requestNotificationPermissionUseCase
       )
       
-    case .AvoidContactsGuide:
+    case .avoidContactsGuide:
       let blockcontactsrepository = repositoryFactory.createBlockContactsRepository()
       let checkContactsPermissionUseCase = UseCaseFactory.createCheckContactsPermissionUseCase()
       let requestContactsPermissionUseCase = UseCaseFactory.createRequestContactsPermissionUseCase(checkContactsPermissionUseCase: checkContactsPermissionUseCase)

--- a/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideView.swift
+++ b/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideView.swift
@@ -105,7 +105,7 @@ struct AvoidContactsGuideView: View {
   private var denyButton: some View {
     PCTextButton(content: Constant.denyButtonText)
       .onTapGesture {
-        router.push(to: .completeSignUp)
+        viewModel.handleAction(.tapDenyButton)
       }
       .padding(.bottom, 20)
   }

--- a/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideView.swift
+++ b/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideView.swift
@@ -75,8 +75,14 @@ struct AvoidContactsGuideView: View {
         .animation(.easeInOut(duration: 0.3), value: viewModel.showToast)
     }
     .toolbar(.hidden)
+    .allowsHitTesting(!viewModel.isProcessingShowToast)
+    .onAppear {
+      viewModel.handleAction(.onAppear)
+    }
     .onChange(of: viewModel.moveToCompleteSignUp) { _, newValue in
-      router.push(to: .completeSignUp)
+      if newValue {
+        router.push(to: .completeSignUp)
+      }
     }
   }
   

--- a/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideViewModel.swift
@@ -15,6 +15,7 @@ import Entities
 final class AvoidContactsGuideViewModel {
   enum Action {
     case onAppear
+    case tapDenyButton
     case tapAcceptButton
     case showShettingAlert
     case cancelAlert
@@ -43,6 +44,9 @@ final class AvoidContactsGuideViewModel {
     case .onAppear:
       initializeState()
 
+    case .tapDenyButton:
+      moveToCompleteSignUp = true
+      
     case .tapAcceptButton:
       Task {
         await handleAcceptButtonTap()
@@ -91,5 +95,12 @@ final class AvoidContactsGuideViewModel {
           UIApplication.shared.canOpenURL(url) else { return }
     
     UIApplication.shared.open(url)
+  }
+  
+  private func initializeState() {
+    showToast = false
+    moveToCompleteSignUp = false
+    isPresentedAlert = false
+    isProcessingShowToast = false
   }
 }

--- a/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideViewModel.swift
@@ -14,12 +14,14 @@ import Entities
 @Observable
 final class AvoidContactsGuideViewModel {
   enum Action {
+    case onAppear
     case tapAcceptButton
     case showShettingAlert
     case cancelAlert
   }
   
   private(set) var showToast = false
+  private(set) var isProcessingShowToast = false
   private(set) var moveToCompleteSignUp: Bool = false
   var isPresentedAlert: Bool = false
   private let requestContactsPermissionUseCase: RequestContactsPermissionUseCase
@@ -38,12 +40,17 @@ final class AvoidContactsGuideViewModel {
   
   func handleAction(_ action: Action) {
     switch action {
+    case .onAppear:
+      initializeState()
+
     case .tapAcceptButton:
       Task {
         await handleAcceptButtonTap()
       }
+      
     case .showShettingAlert:
       openSettings()
+      
     case .cancelAlert:
       isPresentedAlert = false
     }
@@ -69,10 +76,14 @@ final class AvoidContactsGuideViewModel {
   @MainActor
   private func isToastVisible() async {
     showToast = true
+    isProcessingShowToast = true /// Showing Toast
+    
     try? await Task.sleep(for: .seconds(2))
     showToast = false
     try? await Task.sleep(for: .seconds(0.3)) // 토스트가 사라지는 애니메이션 이후 화면 전환하기 위함
-    moveToCompleteSignUp = true
+    
+    moveToCompleteSignUp = true /// Hiding Toast
+    isProcessingShowToast = false
   }
   
   private func openSettings() {

--- a/Presentation/Feature/SignUp/Sources/PermissionRequest/PermissionRequestView.swift
+++ b/Presentation/Feature/SignUp/Sources/PermissionRequest/PermissionRequestView.swift
@@ -80,6 +80,9 @@ struct PermissionRequestView: View {
     .task {
       await viewModel.checkPermissions()
     }
+    .onAppear {
+      viewModel.handleAction(.onAppear)
+    }
     .onChange(of: scenePhase) {
       if scenePhase == .active {
         Task {
@@ -88,7 +91,9 @@ struct PermissionRequestView: View {
       }
     }
     .onChange(of: viewModel.showToAvoidContactsView) { _, newValue in
-      router.push(to: .AvoidContactsGuide)
+      if newValue {
+        router.push(to: .avoidContactsGuide)
+      }
     }
     .alert("필수 권한 요청", isPresented: $viewModel.shouldShowSettingsAlert) {
       Button("설정으로 이동") {

--- a/Presentation/Feature/SignUp/Sources/PermissionRequest/PermissionRequestViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/PermissionRequest/PermissionRequestViewModel.swift
@@ -27,6 +27,7 @@ final class PermissionRequestViewModel {
   private let requestNotificationPermissionUseCase: RequestNotificationPermissionUseCase
   
   enum Action {
+    case onAppear
     case showShettingAlert
     case tapNextButton
     case cancelAlert
@@ -46,18 +47,34 @@ final class PermissionRequestViewModel {
   
   func handleAction(_ action: Action) {
     switch action {
+    case .onAppear:
+      resetNavigationState()
+      
     case .showShettingAlert:
       openSettings()
+      
     case .cancelAlert:
       Task { await resetAlertState() }
+      
     case .tapNextButton:
-      showToAvoidContactsView = true
+      navigateToAvoidContactsView()
     }
   }
   
   func checkPermissions() async {
     await fetchPermissions()
     await updateSettingsAlertState()
+  }
+}
+
+// MARK: 네비게이팅
+private extension PermissionRequestViewModel {
+  func navigateToAvoidContactsView() {
+    showToAvoidContactsView = true
+  }
+  
+  func resetNavigationState() {
+    showToAvoidContactsView = false
   }
 }
 

--- a/Presentation/Router/Sources/Route.swift
+++ b/Presentation/Router/Sources/Route.swift
@@ -16,7 +16,7 @@ public enum Route: Hashable {
   
   // MARK: - 회원가입
   case verifyContact
-  case AvoidContactsGuide
+  case avoidContactsGuide
   case termsAgreement
   case termsWebView(term: TermModel)
   case checkPremission


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1201](https://yapp25app3.atlassian.net/browse/PC-1201)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - PermissionRequestView의 라우팅 플래그 초기화 이슈로 인해 백버튼으로 PermissionRequestView에 진입 시 "다음"버튼이 동작하지 않는 문제를 해결
  - 일부 enum case 네이밍 컨벤션 적용
  -  상태기반 라우팅을 통해 사용자 인터랙션 중복 방지
  - 아는 사람 차단하기 화면에서 토스트가 나타나는 동안 사용자 인터랙션 방지
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1201]: https://yapp25app3.atlassian.net/browse/PC-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ