### PR TITLE
[PC-1235] Fix: FCM 토큰 등록/해제 관련 이슈 해결

### DIFF
--- a/Data/LocalStorage/Sources/Keychain/PCKeychain.swift
+++ b/Data/LocalStorage/Sources/Keychain/PCKeychain.swift
@@ -10,4 +10,5 @@ import Foundation
 public enum PCKeychain: String, CaseIterable {
   case accessToken
   case refreshToken
+  case fcmToken
 }

--- a/Data/Repository/Sources/Login/LoginRepository.swift
+++ b/Data/Repository/Sources/Login/LoginRepository.swift
@@ -10,6 +10,7 @@ import Entities
 import LocalStorage
 import PCNetwork
 import RepositoryInterfaces
+import Foundation
 
 public final class LoginRepository: LoginRepositoryInterface {
 
@@ -29,6 +30,12 @@ public final class LoginRepository: LoginRepositoryInterface {
     PCKeychainManager.shared.save(.accessToken, value: responseDTO.accessToken)
     PCKeychainManager.shared.save(.refreshToken, value: responseDTO.refreshToken)
     networkService.updateCredentials()
+    
+    if let fcmToken = PCKeychainManager.shared.read(.fcmToken) {
+      let dataDict: [String: String] = ["token": fcmToken]
+      NotificationCenter.default.post(name: .fcmToken, object: nil, userInfo: dataDict)
+    }
+
     return responseDTO.toDomain()
   }
   

--- a/Presentation/Feature/Settings/Sources/SettingsViewModel.swift
+++ b/Presentation/Feature/Settings/Sources/SettingsViewModel.swift
@@ -368,9 +368,25 @@ final class SettingsViewModel {
     }
     showLogoutAlert = false
     
-    PCKeychainManager.shared.deleteAll()
-    PCUserDefaultsService.shared.initialize()
+    print("✅ Logout started")
+    // fcm 토큰 제외 모두 지우기 (앱을 종료하지 않고 바로 다시 로그인하는 경우 fcm 토큰을 서버에 등록해야함)
+    clearUserDataPreservingFCMToken()
+    
     // 로그아웃 시 splash로 이동
     destination = .splash
+    print("✅ Logout completed - moved to splash")
+  }
+  
+  private func clearUserDataPreservingFCMToken() {
+    let fcmToken = PCKeychainManager.shared.read(.fcmToken)
+    PCKeychainManager.shared.deleteAll()
+    PCUserDefaultsService.shared.initialize()
+    
+    if let fcmToken {
+      PCKeychainManager.shared.save(.fcmToken, value: fcmToken)
+      print("✅ User data cleared with FCM token preserved")
+    } else {
+      print("✅ User data cleared")
+    }
   }
 }

--- a/Presentation/Feature/Splash/Sources/SplashViewModel.swift
+++ b/Presentation/Feature/Splash/Sources/SplashViewModel.swift
@@ -67,7 +67,7 @@ final class SplashViewModel {
         guard !showNeedsForceUpdateAlert else { return }
         
         guard checkOnboarding() else { return }
-        checkAccesstoken()
+        guard checkAccesstoken() else { return }
         try await setRoute()
       } catch let error as NetworkError {
         var destination: Route = .login
@@ -148,14 +148,15 @@ final class SplashViewModel {
     return true
   }
   
-  private func checkAccesstoken() {
+  private func checkAccesstoken() -> Bool {
     // 로그인 여부 확인 ( AccessToken 유무 확인 )
     guard let accessToken = PCKeychainManager.shared.read(.accessToken) else {
       print("AccessToken이 없어서 로그인 화면으로 이동")
       destination = .login
-      return
+      return false
     }
     print("SplashView AccessToken: \(accessToken)")
+    return true
   }
   
   private func openAppStore() {

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmViewModel.swift
@@ -154,12 +154,23 @@ final class WithdrawConfirmViewModel: NSObject {
   }
   
   private func initialize() {
-    print("✅ Initialize started")
-    PCKeychainManager.shared.deleteAll()
-    print("✅ Keychain deleted")
-    PCUserDefaultsService.shared.initialize()
-    print("✅ UserDefaults initialized")
+    print("✅ Withdraw started")
+    clearUserDataPreservingFCMToken()
+    
     destination = .splash
-    print("✅ splash로 이동")
+    print("✅ Withdraw completed - moved to splash")
+  }
+  
+  private func clearUserDataPreservingFCMToken() {
+    let fcmToken = PCKeychainManager.shared.read(.fcmToken)
+    PCKeychainManager.shared.deleteAll()
+    PCUserDefaultsService.shared.initialize()
+    
+    if let fcmToken {
+      PCKeychainManager.shared.save(.fcmToken, value: fcmToken)
+      print("✅ User data cleared with FCM token preserved")
+    } else {
+      print("✅ User data cleared")
+    }
   }
 }

--- a/Utility/PCFirebase/Project.swift
+++ b/Utility/PCFirebase/Project.swift
@@ -11,9 +11,6 @@ import ProjectDescriptionHelpers
 let project = Project.dynamicResourceFramework(
   name: Modules.Utility.PCFirebase.rawValue,
   dependencies: [
-    .data(target: .PCNetwork),
-    .data(target: .Repository),
-    .domain(target: .UseCases),
     .externalDependency(dependency: .FirebaseAnalytics),
     .externalDependency(dependency: .FirebaseCore),
     .externalDependency(dependency: .FirebaseMessaging),

--- a/Utility/PCFirebase/Sources/PCNotificationService.swift
+++ b/Utility/PCFirebase/Sources/PCNotificationService.swift
@@ -6,10 +6,8 @@
 //
 
 import FirebaseMessaging
-import PCNetwork
-import Repository
+import PCFoundationExtension
 import UIKit
-import UseCases
 
 public final class PCNotificationService: NSObject, UNUserNotificationCenterDelegate, MessagingDelegate {
   public static let shared = PCNotificationService()
@@ -171,28 +169,12 @@ public final class PCNotificationService: NSObject, UNUserNotificationCenterDele
     didReceiveRegistrationToken fcmToken: String?
   ) {
     if let fcmToken {
+      let dataDict: [String: String] = ["token": fcmToken]
+      
+      NotificationCenter.default.post(name: .fcmToken, object: nil, userInfo: dataDict)
+      
       print("🔥 Firebase FCM 토큰 수신: \(fcmToken)")
       print("🔥 토큰 길이: \(fcmToken.count) 문자")
-      
-      let dataDict: [String: String] = ["token": fcmToken]
-      NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil, userInfo: dataDict)
-      
-      // 서버에 FCM 토큰을 전송하는 로직
-      print("🔥 서버에 FCM 토큰 전송 시작...")
-      let repositoryFactory = RepositoryFactory(
-        networkService: NetworkService.shared,
-        sseService: SSEService.shared
-      )
-      let loginRepository = repositoryFactory.createLoginRepository()
-      let registerFcmTokenUseCase = UseCaseFactory.createRegisterFcmTokenUseCase(repository: loginRepository)
-      Task {
-        do {
-          _ = try await registerFcmTokenUseCase.execute(token: fcmToken)
-          print("🔥 서버에 FCM 토큰 전송 성공")
-        } catch {
-          print("🔥 서버에 FCM 토큰 전송 실패: \(error)")
-        }
-      }
     } else {
       print("🔥 FCM 토큰이 nil입니다")
     }

--- a/Utility/PCFoundationExtension/Sources/Notification.Name+.swift
+++ b/Utility/PCFoundationExtension/Sources/Notification.Name+.swift
@@ -10,4 +10,5 @@ import Foundation
 // MARK: - Push Notifications
 public extension Notification.Name {
   static let deepLinkHome = Notification.Name("DeepLinkHome")
+  static let fcmToken = Notification.Name("FCMToken")
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1235](https://yapp25app3.atlassian.net/browse/PC-1235)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 로그아웃/회원탈퇴 후 앱을 종료하지 않고 바로 로그인 시 서버에 FCM 토큰을 등록하지 못하는 문제 개선
  - 최초 회원가입 및 로그인 시 AccessToken 없이 FCM 토큰을 서버에 등록할 수 없어 푸쉬 알림이 정상적으로 동작하지 않는 문제 개선
  - PCFirebase의 FCM 토큰 등록 책임을 AppDelegate로 위임 및 책임 분리, 이로인한 불필요한 의존성 제거
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1235]: https://yapp25app3.atlassian.net/browse/PC-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ