### PR TITLE
[PC-1227] Fix: PCBottomSheet KeyboardDidShow 시 스크롤 구현

### DIFF
--- a/Presentation/DesignSystem/Sources/PCBottomSheet.swift
+++ b/Presentation/DesignSystem/Sources/PCBottomSheet.swift
@@ -214,22 +214,38 @@ public struct PCBottomSheet<T: BottomSheetItemRepresentable>: View {
   }
 
   public var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      header
-        .padding(.vertical, 8)
-      
-      Spacer()
-        .frame(maxHeight: 12)
-      
-      content
-      
-      Spacer()
-      
-      button
-        .padding(.bottom, 10)
+    ScrollViewReader { proxy in
+      ScrollView {
+        VStack(alignment: .leading, spacing: 0) {
+          header
+            .padding(.vertical, 8)
+          
+          Spacer()
+            .frame(maxHeight: 12)
+          
+          content
+          
+          Spacer()
+          
+          button
+            .padding(.bottom, 10)
+            .id("bottomButton")
+        }
+        .padding(.top, 28)
+        .padding(.horizontal, 20)
+      }
+      .scrollIndicators(.hidden)
+      .scrollDisabled(true)
+      .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
+        Task {
+          await MainActor.run {
+            withAnimation(.easeInOut(duration: 0.3)) {
+              proxy.scrollTo("bottomButton", anchor: .top)
+            }
+          }
+        }
+      }
     }
-    .padding(.top, 28)
-    .padding(.horizontal, 20)
   }
 
   private var header: some View {


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1227](https://yapp25app3.atlassian.net/browse/PC-1227)

## 👷🏼‍♂️ 변경 사항
- 최하단 Bottom Button으로 스크롤 되도록 구현
- 중첩 스크롤 구조에서 내부 Content만 스크롤 가능하도록 구현
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)


https://github.com/user-attachments/assets/117ccb3a-eed3-4da1-bd4d-97ece3c58fc3



