### PR TITLE
[PC-1229] Fix: ClearButton 관련 이슈 수정

### DIFF
--- a/Presentation/DesignSystem/Sources/PCBottomSheet.swift
+++ b/Presentation/DesignSystem/Sources/PCBottomSheet.swift
@@ -85,6 +85,7 @@ public enum BottomSheetItemType {
 }
 
 public struct BottomSheetTextItem: BottomSheetItemRepresentable {
+  @State private var hasValue: Bool = false
   @Binding public var value: String
   
   public var id: UUID
@@ -115,7 +116,7 @@ public struct BottomSheetTextItem: BottomSheetItemRepresentable {
           .frame(maxHeight: 19)
         
         if state == .selected {
-          textField
+          PCBottomSheetTextFieldRow(value: $value)
           
           Spacer()
         }
@@ -136,21 +137,7 @@ public struct BottomSheetTextItem: BottomSheetItemRepresentable {
       }
     }
   }
-  private var textField: some View {
-    TextField("자유롭게 작성해주세요", text: $value)
-      .autocorrectionDisabled()
-      .multilineTextAlignment(.leading)
-      .textInputAutocapitalization(.none)
-      .pretendard(.body_M_M)
-      .frame(height: 52)
-      .padding(.horizontal, 16)
-      .background(.grayscaleLight3)
-      .cornerRadius(8)
-      .onAppear {
-        UITextField.appearance().clearButtonMode = .whileEditing
-      }
-  }
-
+  
   public func hash(into hasher: inout Hasher) {
       hasher.combine(id)
   }
@@ -180,6 +167,44 @@ public struct BottomSheetTextItem: BottomSheetItemRepresentable {
     self.type = .custom(text)
     self.state = state
     self._value = value
+  }
+}
+
+fileprivate struct PCBottomSheetTextFieldRow: View {
+  @Binding var value: String
+  @State private var hasValue: Bool = false
+
+  var body: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: 8)
+        .fill(Color.grayscaleLight3)
+
+      HStack(spacing: 0) {
+        TextField("자유롭게 작성해주세요", text: $value)
+          .autocorrectionDisabled()
+          .multilineTextAlignment(.leading)
+          .textInputAutocapitalization(.none)
+          .pretendard(.body_M_M)
+          .onChange(of: value) { _, newValue in
+            hasValue = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          }
+
+        if hasValue {
+          Button {
+            value = ""
+          } label: {
+            DesignSystemAsset.Icons.deletCircle20.swiftUIImage
+              .renderingMode(.template)
+              .foregroundStyle(Color.grayscaleLight1)
+          }
+        }
+      }
+      .padding(.horizontal, 16)
+      .onAppear {
+        hasValue = !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      }
+    }
+    .frame(height: 52)
   }
 }
 

--- a/Presentation/DesignSystem/Sources/PCTextField.swift
+++ b/Presentation/DesignSystem/Sources/PCTextField.swift
@@ -77,7 +77,7 @@ public struct PCTextField<FocusField: Hashable>: View {
   
   @ViewBuilder
   private var clearButton: some View {
-    if showClearButton && ( !text.isEmpty || focusState.wrappedValue == focusField) {
+    if showClearButton && (!text.isEmpty || focusState.wrappedValue == focusField) {
       Button {
         text = ""
       } label: {

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -326,6 +326,7 @@ struct EditProfileView: View {
       color: viewModel.nicknameState.infoTextColor
     )
     .textMaxLength(6)
+    .showClearButton(true)
     .onSubmit {
       focusField = "description"
     }
@@ -347,6 +348,7 @@ struct EditProfileView: View {
       color: .systemError
     )
     .textMaxLength(20)
+    .showClearButton(true)
     .onSubmit {
       focusField = "birthDate"
     }
@@ -367,6 +369,7 @@ struct EditProfileView: View {
       viewModel.birthDateInfoText,
       color: .systemError
     )
+    .showClearButton(true)
     .onChange { newValue in
       viewModel.birthDate = String(newValue.filter { $0.isNumber }.prefix(8))
       viewModel.handleAction(.updateEditingState)

--- a/Presentation/Feature/SignUp/Sources/CreateEditRejectedProfile/BasicInfo/EditRejectedBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateEditRejectedProfile/BasicInfo/EditRejectedBasicInfoView.swift
@@ -301,6 +301,7 @@ struct EditRejectedBasicInfoView: View {
       color: viewModel.nicknameState.infoTextColor
     )
     .textMaxLength(6)
+    .showClearButton(true)
     .onSubmit {
       focusField = "description"
     }
@@ -322,6 +323,7 @@ struct EditRejectedBasicInfoView: View {
       color: .systemError
     )
     .textMaxLength(20)
+    .showClearButton(true)
     .onSubmit {
       focusField = "birthDate"
     }
@@ -339,6 +341,7 @@ struct EditRejectedBasicInfoView: View {
       viewModel.birthDateInfoText,
       color: .systemError
     )
+    .showClearButton(true)
     .onChange { newValue in
       viewModel.birthDate = String(newValue.filter { $0.isNumber }.prefix(8))
     }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -288,6 +288,7 @@ struct CreateBasicInfoView: View {
       color: viewModel.nicknameState.infoTextColor
     )
     .textMaxLength(6)
+    .showClearButton(true)
     .onSubmit {
       focusField = "description"
     }
@@ -309,6 +310,7 @@ struct CreateBasicInfoView: View {
       color: .systemError
     )
     .textMaxLength(20)
+    .showClearButton(true)
     .onSubmit {
       focusField = "birthDate"
     }
@@ -326,6 +328,7 @@ struct CreateBasicInfoView: View {
       viewModel.birthDateInfoText,
       color: .systemError
     )
+    .showClearButton(true)
     .onChange { newValue in
       viewModel.birthDate = String(newValue.filter { $0.isNumber }.prefix(8))
     }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-](https://yapp25app3.atlassian.net/browse/PC-)

## 👷🏼‍♂️ 변경 사항
### 누락된 ClearButton들 추가
- 닉네임
- 나를 표현하는 한 마디
- 생년월일

### ClearButton 이슈
```swift
onAppear {
  UITextField.appearance().clearButtonMode = .whileEditing
}
```
**AS-IS**
- 위 코드로 인해 직업 바텀시트의 기타 탭 진입 후 다른 TextField에서 의도치 않게 ClearButton이 나타나는 현상이 발생함.

**TO-BE**
- 위 코드를 제거하고 ClearButton을 포함한 텍스트필드를 커스텀하여 구현
 

```diff
--- a/Presentation/DesignSystem/Sources/PCBottomSheet.swift
+++ b/Presentation/DesignSystem/Sources/PCBottomSheet.swift

-  private var textField: some View {
-    TextField("자유롭게 작성해주세요", text: $value)
-      .autocorrectionDisabled()
-      .multilineTextAlignment(.leading)
-      .textInputAutocapitalization(.none)
-      .pretendard(.body_M_M)
-      .frame(height: 52)
-      .padding(.horizontal, 16)
-      .background(.grayscaleLight3)
-      .cornerRadius(8)
-      .onAppear {
-        UITextField.appearance().clearButtonMode = .whileEditing
-      }
-  }


+  fileprivate struct PCBottomSheetTextFieldRow: View {
+    @Binding var value: String
+    @State private var hasValue: Bool = false
+  
+    var body: some View {
+      ZStack {
+        RoundedRectangle(cornerRadius: 8)
+          .fill(Color.grayscaleLight3)
+  
+        HStack(spacing: 0) {
+          TextField("자유롭게 작성해주세요", text: $value)
+            .autocorrectionDisabled()
+            .multilineTextAlignment(.leading)
+            .textInputAutocapitalization(.none)
+            .pretendard(.body_M_M)
+            .onChange(of: value) { _, newValue in
+              hasValue = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+  
+          if hasValue {
+            Button {
+              value = ""
+            } label: {
+              DesignSystemAsset.Icons.deletCircle20.swiftUIImage
+                .renderingMode(.template)
+                .foregroundStyle(Color.grayscaleLight1)
+            }
+          }
+        }
+        .padding(.horizontal, 16)
+        .onAppear {
+          hasValue = !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+      }
+      .frame(height: 52)
+    }
+  }
```

## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 누락된 곳들 | 변경한 BottomSheet의 기타 탭 |
| :--: |:--: |
| ![1](https://github.com/user-attachments/assets/a52a19b6-268c-4eed-b4c4-e394163fca61) |  ![2](https://github.com/user-attachments/assets/ac2239c5-ee87-4e57-a388-a374da129a4a) | 