### PR TITLE
[PC-1240] Fix: TextEditor 초기 값에 맞게 동적 높이 반영 되지 않는 이슈 수정

### DIFF
--- a/Presentation/DesignSystem/Sources/PCContactField.swift
+++ b/Presentation/DesignSystem/Sources/PCContactField.swift
@@ -90,7 +90,7 @@ public struct PCContactField: View {
       }
 
       if contact.type == .openKakao, estimatedLineCount >= 2 {
-        Spacer()
+        Spacer(minLength: 0)
       }
     }
   }
@@ -112,6 +112,15 @@ public struct PCContactField: View {
               }
           }
         )
+        .onAppear {
+          Task {
+            await MainActor.run {
+              let copy = contact.value
+              contact.value = copy
+            }
+          }
+        }
+
     default:
       TextField("", text: $contact.value)
         .pretendard(.body_M_M)


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1240](https://yapp25app3.atlassian.net/browse/PC-1240)

## 👷🏼‍♂️ 변경 사항
- onAppear 시점에 메인 스레드로 바인딩 카피 및 재할당을 통해 레이아웃 계산을 트리거 활성화
- contact.value를 재할당하여 높이 변경 관련 UI 메인 런루프 유도

 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| Before |  After | 
| :--: | :--: |
| ![before](https://github.com/user-attachments/assets/629bd94f-24d9-4d65-b189-98723a8eecbf) |  ![after](https://github.com/user-attachments/assets/0392961c-08f2-4f46-b533-50dbd9cfe92f) |

[PC-1240]: https://yapp25app3.atlassian.net/browse/PC-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ