### PR TITLE
[PC-752] Feature: Firebase Crashlytics 세팅

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -10,7 +10,6 @@ let project = Project.app(
     .externalDependency(dependency: .KakaoSDKAuth),
     .externalDependency(dependency: .KakaoSDKUser),
     .externalDependency(dependency: .GoogleSignIn),
-    .externalDependency(dependency: .GoogleSignInSwift),
     .utility(target: .PCFirebase),
     .utility(target: .PCAmplitude)
   ]

--- a/App/Sources/PieceApp.swift
+++ b/App/Sources/PieceApp.swift
@@ -7,7 +7,6 @@ import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
 import GoogleSignIn
-import GoogleSignInSwift
 import SwiftUI
 
 @main

--- a/Presentation/Feature/MatchingMain/Project.swift
+++ b/Presentation/Feature/MatchingMain/Project.swift
@@ -15,6 +15,5 @@ let project = Project.staticLibrary(
     .presentation(target: .Router),
     .utility(target: .PCFoundationExtension),
     .utility(target: .PCAmplitude),
-    .utility(target: .PCAmplitude),
   ]
 )

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1eaba9a6b115709338154471a640a0fcc549c174049107f817a1c6631f6d1fae",
+  "originHash" : "1c4b0d4a30d5e6d4323d136f920d1d0f2b3318acb84c25257567074f6c6d98a7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/Tuist/ProjectDescriptionHelpers/ExternalDependencies.swift
+++ b/Tuist/ProjectDescriptionHelpers/ExternalDependencies.swift
@@ -18,6 +18,7 @@ public enum ExternalDependencies {
   case FirebaseRemoteConfig
   case FirebaseCore
   case FirebaseAnalytics
+  case FirebaseCrashlytics
   case FirebaseMessaging
   case Mantis
   case AmplitudeSwift
@@ -34,6 +35,7 @@ public enum ExternalDependencies {
     case .FirebaseRemoteConfig: "FirebaseRemoteConfig"
     case .FirebaseCore: "FirebaseCore"
     case .FirebaseAnalytics: "FirebaseAnalytics"
+    case .FirebaseCrashlytics: "FirebaseCrashlytics"
     case .FirebaseMessaging: "FirebaseMessaging"
     case .Mantis: "Mantis"
     case .AmplitudeSwift: "AmplitudeSwift"

--- a/Tuist/ProjectDescriptionHelpers/ExternalDependencies.swift
+++ b/Tuist/ProjectDescriptionHelpers/ExternalDependencies.swift
@@ -13,7 +13,6 @@ public enum ExternalDependencies {
   case KakaoSDKAuth
   case KakaoSDKUser
   case GoogleSignIn
-  case GoogleSignInSwift
   case Lottie
   case FirebaseRemoteConfig
   case FirebaseCore
@@ -27,7 +26,6 @@ public enum ExternalDependencies {
     switch self {
     case .Alamofire: "Alamofire"
     case .GoogleSignIn: "GoogleSignIn"
-    case .GoogleSignInSwift: "GoogleSignInSwift"
     case .KakaoSDKCommon: "KakaoSDKCommon"
     case .KakaoSDKAuth: "KakaoSDKAuth"
     case .KakaoSDKUser: "KakaoSDKUser"

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
@@ -190,6 +190,19 @@ extension Target {
         )
       ),
       entitlements: .file(path: .relativeToRoot("Piece-iOS.entitlements")),
+      scripts: [
+        .post(
+          script: "${SRCROOT}/../Tuist/.build/checkouts/firebase-ios-sdk/Crashlytics/run",
+          name: "Firebase Crashlytics dSYM Upload",
+          inputPaths: [
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+            "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+            "$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+          ]
+        )
+      ],
       dependencies: dependencies,
       settings: .settings(
         base: [
@@ -198,6 +211,7 @@ extension Target {
           "DEVELOPMENT_TEAM": SettingValue.string(AppConstants.developmentTeam),
           "MARKETING_VERSION": SettingValue.string(AppConstants.versionString),
           "CURRENT_PROJECT_VERSION": SettingValue.string(AppConstants.buildString),
+          "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
         ],
         configurations: [
           .configuration(environment: .Debug),

--- a/Utility/PCAmplitude/Project.swift
+++ b/Utility/PCAmplitude/Project.swift
@@ -8,7 +8,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = Project.dynamicResourceFramework(
+let project = Project.dynamicFramework(
   name: Modules.Utility.PCAmplitude.rawValue,
   dependencies: [
     .data(target: .LocalStorage),

--- a/Utility/PCFirebase/Project.swift
+++ b/Utility/PCFirebase/Project.swift
@@ -12,6 +12,7 @@ let project = Project.dynamicResourceFramework(
   name: Modules.Utility.PCFirebase.rawValue,
   dependencies: [
     .externalDependency(dependency: .FirebaseAnalytics),
+    .externalDependency(dependency: .FirebaseCrashlytics),
     .externalDependency(dependency: .FirebaseCore),
     .externalDependency(dependency: .FirebaseMessaging),
     .externalDependency(dependency: .FirebaseRemoteConfig),

--- a/Utility/PCFirebase/Sources/PCFirebase.swift
+++ b/Utility/PCFirebase/Sources/PCFirebase.swift
@@ -6,6 +6,7 @@
 //
 
 import FirebaseCore
+import FirebaseCrashlytics
 import FirebaseRemoteConfig
 
 public final class PCFirebase {
@@ -23,7 +24,19 @@ public final class PCFirebase {
     
     if FirebaseApp.app() == nil {
       FirebaseApp.configure(options: options)
+      
+      setCrashlytics()
     }
+  }
+  
+  private func setCrashlytics() {
+    #if DEBUG
+    Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
+    NSLog("🔥 Crashlytics disabled in DEBUG mode")
+    #else
+    Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
+    NSLog("🔥 Crashlytics enabled in RELEASE mode")
+    #endif
   }
   
   public func setRemoteConfig() throws {
@@ -84,6 +97,38 @@ public final class PCFirebase {
   
   public func needsForceUpdate() -> Bool {
     return bool(forKey: .needsForceUpdate)
+  }
+}
+
+extension PCFirebase {
+  public func logCrashlytics(_ message: String) {
+    Crashlytics.crashlytics().log(message)
+  }
+  
+  public func setCrashlyticsUserId(_ userId: String) {
+    Crashlytics.crashlytics().setUserID(userId)
+  }
+  
+  public func setCrashlyticsCustomKey(_ key: String, value: Any) {
+    Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+  }
+  
+  public func recordCrashlyticsError(_ error: Error) {
+    Crashlytics.crashlytics().record(error: error)
+  }
+  
+  public func testCrashlytics() {
+    // 커스텀 로그 기록
+    logCrashlytics("Test log message")
+    
+    // 커스텀 키 설정
+    setCrashlyticsCustomKey("test_key", value: "test_value")
+    
+    // 비치명적 오류 기록
+    let error = NSError(domain: "TestDomain", code: 123, userInfo: [NSLocalizedDescriptionKey: "Test error"])
+    recordCrashlyticsError(error)
+    
+    print("🔥 Crashlytics 테스트 데이터 전송 완료")
   }
 }
 


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-752](https://yapp25app3.atlassian.net/browse/PC-752)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - Firebase Crashlytics 관련 의존성 추가 및 설정
  - 아래와 같이배포시에만 수집하도록 제어
 ```swift
// PCFirebase.swift

   private func setCrashlytics() {
    #if DEBUG
    Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
    NSLog("🔥 Crashlytics disabled in DEBUG mode")
    #else
    Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
    NSLog("🔥 Crashlytics enabled in RELEASE mode")
    #endif
  }
 ```
## 💬 참고 사항
- 1.0.4 배포 예정

## 📸 스크린샷(Optional)
| Release 정상 작동 |
| :--: |
| <img width="1053" height="774" alt="image" src="https://github.com/user-attachments/assets/1cd03b53-7050-4d5b-8399-d5607f75cb84" /> |

[PC-752]: https://yapp25app3.atlassian.net/browse/PC-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ