### PR TITLE
[PC-1151] Feature: NotificationType 페이로드에 따른 APNs DeepLink Routing 처리

### DIFF
--- a/Domain/Entities/Sources/Home/HomeViewTab.swift
+++ b/Domain/Entities/Sources/Home/HomeViewTab.swift
@@ -1,0 +1,28 @@
+//
+//  HomeViewTab.swift
+//  Home
+//
+//  Created by 홍승완 on 9/30/25.
+//
+
+import Foundation
+
+public enum HomeViewTab: String {
+  case profile
+  case home
+  case settings
+  
+  public init?(rawValue: String) {
+    switch rawValue {
+      case "profile":
+      self = .profile
+    case "home":
+      self = .home
+    case "settings":
+      self = .settings
+    default:
+      self = .home
+    }
+  }
+}
+

--- a/Domain/Entities/Sources/Notification/NotificationType.swift
+++ b/Domain/Entities/Sources/Notification/NotificationType.swift
@@ -14,3 +14,18 @@ public enum NotificationType {
   case matchAccepted
   case matchCompleted
 }
+
+public extension NotificationType {
+  static func from(raw: String) -> NotificationType? {
+    switch raw {
+    case "PROFILE_APPROVED": return .profileApproved
+    case "PROFILE_REJECTED": return .profileRejected
+    case "PROFILE_IMAGE_APPROVED": return .profileImageApproved
+    case "PROFILE_IMAGE_REJECTED": return .profileImageRejected
+    case "MATCH_NEW": return .matchNew
+    case "MATCH_ACCEPTED": return .matchAccepted
+    case "MATCH_COMPLETED": return .matchCompleted
+    default: return nil
+    }
+  }
+}

--- a/Presentation/Coordinator/Sources/Coordinator.swift
+++ b/Presentation/Coordinator/Sources/Coordinator.swift
@@ -90,6 +90,7 @@ public struct Coordinator {
       let putSettingsBlockAcquaintanceUseCase = UseCaseFactory.createPutSettingsBlockAcquaintanceUseCase(repository: settingsRepository)
       let patchLogoutUseCase = UseCaseFactory.createLogoutUseCase(repository: settingsRepository)
       HomeViewFactory.createHomeView(
+        selectedTab: .home,
         getProfileUseCase: getProfileUseCase,
         getUserInfoUseCase: getUserInfoUseCase,
         acceptMatchUseCase: acceptMatchUseCase,
@@ -290,6 +291,57 @@ public struct Coordinator {
       SignUpViewFactory.createCompleteEditRejectedProfileView()
       
       // MARK: - Profile
+    case .profileBasic:
+      let profileRepository = repositoryFactory.createProfileRepository()
+      let matchesRepository = repositoryFactory.createMatchesRepository()
+      let termsRepository = repositoryFactory.createTermsRepository()
+      let blockContactsRepository = repositoryFactory.createBlockContactsRepository()
+      let settingsRepository = repositoryFactory.createSettingsRepository()
+      let userRepository = repositoryFactory.createUserRepository()
+      // profile
+      let getProfileUseCase = UseCaseFactory.createGetProfileUseCase(repository: profileRepository)
+      // matchMain
+      let getUserInfoUseCase = UseCaseFactory.createGetUserInfoUseCase(repository: userRepository)
+      let acceptMatchUseCase = UseCaseFactory.createAcceptMatchUseCase(repository: matchesRepository)
+      let getMatchesInfoUseCase = UseCaseFactory.createGetMatchesInfoUseCase(repository: matchesRepository)
+      let getUserRejectUseCase = UseCaseFactory.createGetUserRejectUseCase(repository: matchesRepository)
+      let patchMatchesCheckPieceUseCase = UseCaseFactory.createPatchMatchesCheckPieceUseCase(repository: matchesRepository)
+      // setting
+      let getSettingsInfoUseCase = UseCaseFactory.createGetSettingsInfoUseCase(repository: settingsRepository)
+      let fetchTermsUseCase = UseCaseFactory.createFetchTermsUseCase(repository: termsRepository)
+      let checkNotificationPermissionUseCase = UseCaseFactory.createCheckNotificationPermissionUseCase()
+      let requestNotificationPermissionUseCase = UseCaseFactory.createRequestNotificationPermissionUseCase()
+      let changeNotificationRegisterStatusUseCase = UseCaseFactory.createChangeNotificationRegisterStatusUseCase()
+      let checkContactsPermissionUseCase = UseCaseFactory.createCheckContactsPermissionUseCase()
+      let requestContactsPermissionUseCase = UseCaseFactory.createRequestContactsPermissionUseCase(checkContactsPermissionUseCase: checkContactsPermissionUseCase)
+      let fetchContactsUseCase = UseCaseFactory.createFetchContactsUseCase()
+      let blockContactsUseCase = UseCaseFactory.createBlockContactsUseCase(repository: blockContactsRepository)
+      let getContactsSyncTimeUseCase = UseCaseFactory.createGetContactsSyncTimeUseCase(repository: settingsRepository)
+      let putSettingsNotificationUseCase = UseCaseFactory.createPutSettingsNotificationUseCase(repository: settingsRepository)
+      let putSettingsBlockAcquaintanceUseCase = UseCaseFactory.createPutSettingsBlockAcquaintanceUseCase(repository: settingsRepository)
+      let patchLogoutUseCase = UseCaseFactory.createLogoutUseCase(repository: settingsRepository)
+      HomeViewFactory.createHomeView(
+        selectedTab: .profile,
+        getProfileUseCase: getProfileUseCase,
+        getUserInfoUseCase: getUserInfoUseCase,
+        acceptMatchUseCase: acceptMatchUseCase,
+        getMatchesInfoUseCase: getMatchesInfoUseCase,
+        getUserRejectUseCase: getUserRejectUseCase,
+        patchMatchesCheckPieceUseCase: patchMatchesCheckPieceUseCase,
+        getSettingsInfoUseCase: getSettingsInfoUseCase,
+        fetchTermsUseCase: fetchTermsUseCase,
+        checkNotificationPermissionUseCase: checkNotificationPermissionUseCase,
+        requestNotificationPermissionUseCase: requestNotificationPermissionUseCase,
+        changeNotificationRegisterStatusUseCase: changeNotificationRegisterStatusUseCase,
+        checkContactsPermissionUseCase: checkContactsPermissionUseCase,
+        requestContactsPermissionUseCase: requestContactsPermissionUseCase,
+        fetchContactsUseCase: fetchContactsUseCase,
+        blockContactsUseCase: blockContactsUseCase,
+        getContactsSyncTimeUseCase: getContactsSyncTimeUseCase,
+        putSettingsNotificationUseCase: putSettingsNotificationUseCase,
+        putSettingsBlockAcquaintanceUseCase: putSettingsBlockAcquaintanceUseCase,
+        patchLogoutUseCase: patchLogoutUseCase
+      )
     case .editValueTalk:
       let profileRepository = repositoryFactory.createProfileRepository()
       let sseRepository = repositoryFactory.createSseRepository()

--- a/Presentation/Feature/Home/Sources/HomeView.swift
+++ b/Presentation/Feature/Home/Sources/HomeView.swift
@@ -12,12 +12,14 @@ import Router
 import Settings
 import SwiftUI
 import UseCases
+import Entities
 
 struct HomeView: View {
   @State private var viewModel: HomeViewModel
   @State private var showProfileToast: Bool = false
   
   init(
+    selectedTab: HomeViewTab,
     getProfileUseCase: GetProfileBasicUseCase,
     getUserInfoUseCase: GetUserInfoUseCase,
     acceptMatchUseCase: AcceptMatchUseCase,
@@ -40,6 +42,7 @@ struct HomeView: View {
   ) {
     _viewModel = .init(
       wrappedValue: .init(
+        selectedTab: selectedTab,
         getProfileUseCase: getProfileUseCase,
         getUserInfoUseCase: getUserInfoUseCase,
         acceptMatchUseCase: acceptMatchUseCase,

--- a/Presentation/Feature/Home/Sources/HomeView.swift
+++ b/Presentation/Feature/Home/Sources/HomeView.swift
@@ -84,6 +84,12 @@ struct HomeView: View {
     }
     .toolbar(.hidden)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .onReceive(NotificationCenter.default.publisher(for: .switchHomeTab)) { notification in
+      if let raw = notification.userInfo?["homeViewTab"] as? String,
+         let tab = HomeViewTab(rawValue: raw) {
+        viewModel.selectedTab = tab
+      }
+    }
   }
   
   @ViewBuilder

--- a/Presentation/Feature/Home/Sources/HomeViewFactory.swift
+++ b/Presentation/Feature/Home/Sources/HomeViewFactory.swift
@@ -7,10 +7,13 @@
 
 import SwiftUI
 import UseCases
+import Entities
 
 public struct HomeViewFactory {
   @ViewBuilder
   public static func createHomeView(
+    // initialTab
+    selectedTab: HomeViewTab,
     // profile
     getProfileUseCase: GetProfileBasicUseCase,
     // matchMain
@@ -35,6 +38,8 @@ public struct HomeViewFactory {
     patchLogoutUseCase: PatchLogoutUseCase
   ) -> some View {
     HomeView(
+      // initialTab
+      selectedTab: selectedTab,
       // profile
       getProfileUseCase: getProfileUseCase,
       // matchMain

--- a/Presentation/Feature/Home/Sources/HomeViewModel.swift
+++ b/Presentation/Feature/Home/Sources/HomeViewModel.swift
@@ -9,19 +9,16 @@ import DesignSystem
 import LocalStorage
 import Observation
 import UseCases
+import Entities
 
 @MainActor
 @Observable
 final class HomeViewModel {
-  enum Tab {
-    case profile
-    case home
-    case settings
-  }
-  
   enum Action { }
   
   init(
+    // initialTab
+    selectedTab: HomeViewTab,
     // profile
     getProfileUseCase: GetProfileBasicUseCase,
     // matchmain
@@ -45,6 +42,8 @@ final class HomeViewModel {
     putSettingsBlockAcquaintanceUseCase: PutSettingsBlockAcquaintanceUseCase,
     patchLogoutUseCase: PatchLogoutUseCase
   ) {
+    // initialTab
+    self.selectedTab = selectedTab
     // profile
     self.getProfileUseCase = getProfileUseCase
     // matchmain
@@ -93,7 +92,7 @@ final class HomeViewModel {
   let patchLogoutUseCase: PatchLogoutUseCase
   
   // MARK: - State
-  var selectedTab: Tab = .home
+  var selectedTab: HomeViewTab
   var isProfileTabDisabled: Bool {
     PCUserDefaultsService.shared.getUserRole() != .USER
   }

--- a/Presentation/Router/Sources/Route.swift
+++ b/Presentation/Router/Sources/Route.swift
@@ -27,13 +27,16 @@ public enum Route: Hashable {
   case matchProfileBasic
   case matchValueTalk
   case matchValuePick
-  case editValueTalk
-  case editValuePick
   case matchResult(nickname: String)
+  
+  // MARK: - 프로필
+  case profileBasic
+  case editProfile
+  case editValuePick
+  case editValueTalk
   
   // MARK: - 설정
   case settingsWebView(title: String, uri: String)
-  case editProfile
   
   // MARK: - 프로필 생성
   case createProfile

--- a/Utility/PCFirebase/Sources/PCNotificationService.swift
+++ b/Utility/PCFirebase/Sources/PCNotificationService.swift
@@ -145,10 +145,15 @@ public final class PCNotificationService: NSObject, UNUserNotificationCenterDele
     print("  - Action Identifier: \(response.actionIdentifier)")
     print("  - UserInfo: \(userInfo)")
     
+    guard let notificationType = userInfo["notificationType"] as? String else {
+      NSLog("🚨 FCM payload에서 'notificationType' 파라미터가 존재하지 않습니다.")
+      return
+    }
+    
     NotificationCenter.default.post(
-      name: .deepLinkHome,
+      name: .deepLink,
       object: nil,
-      userInfo: nil
+      userInfo: ["notificationType": notificationType]
     )
   }
   

--- a/Utility/PCFoundationExtension/Sources/Notification.Name+.swift
+++ b/Utility/PCFoundationExtension/Sources/Notification.Name+.swift
@@ -9,6 +9,7 @@ import Foundation
 
 // MARK: - Push Notifications
 public extension Notification.Name {
-  static let deepLinkHome = Notification.Name("DeepLinkHome")
+  static let deepLink = Notification.Name("DeepLink")
+  static let switchHomeTab = Notification.Name("SwitchHomeTab")
   static let fcmToken = Notification.Name("FCMToken")
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1151](https://yapp25app3.atlassian.net/browse/PC-1151)

## 👷🏼‍♂️ 변경 사항
- 작업 내용
  - 서버 푸시의 NotificationType에 따라 Routing을 구현했습니다.
### NotificationType
- 처리하는 페이로드 rawValue는 아래와 같습니다.
```swift
public extension NotificationType {
  static func from(raw: String) -> NotificationType? {
    switch raw {
    case "PROFILE_APPROVED": return .profileApproved
    case "PROFILE_REJECTED": return .profileRejected
    case "PROFILE_IMAGE_APPROVED": return .profileImageApproved
    case "PROFILE_IMAGE_REJECTED": return .profileImageRejected
    case "MATCH_NEW": return .matchNew
    case "MATCH_ACCEPTED": return .matchAccepted
    case "MATCH_COMPLETED": return .matchCompleted
    default: return nil
    }
  }
}
```
- PCFirebase에서는 의존성 순환을 막기위해 NotificationCenter를 통해 post를 보내어 이를 ContentView에서 파싱하여 DeepLink 처리하도록 구현하였습니다.
  - PCNotificationService → NotificationCenter로 .deepLink 포스트(notificationType String 포함)
  - ContentView에서 onReceive(.deepLink)로 수신 후, NotificationType.from(raw:)로 타입 안전 파싱 및 로그아웃을 고려한 accessToken guard + 라우팅을 수행합니다.
  - `accessToken이 없는 경우 login뷰로 라우팅됩니다.`
  - 홈 내부 탭 전환은 Notification.Name.switchHomeTab로 HomeView가 상태를 갱신합니다.
  - HomeView의 경우 Profile, MatchingMain, Setting이 ZStack으로 쌓여있기 때문에 불가피하게 switchHomeTab으로 노티를 보내어 상태를 변화시키도록 구현되었습니다.
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1151]: https://yapp25app3.atlassian.net/browse/PC-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ