### PR TITLE
[PC-1282] Fix: 신고하기 Radio 버튼 터치 이벤트 충돌 해결

### DIFF
--- a/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
+++ b/Presentation/Feature/ReportUser/Sources/ReportUserView.swift
@@ -127,6 +127,7 @@ struct ReportUserView: View {
     HStack(alignment: .center, spacing: 12) {
       PCRadio(isSelected: .constant(viewModel.selectedReportReason == reason))
         .padding(1)
+        .allowsHitTesting(false)
       
       Text(reason.rawValue)
         .pretendard(.body_M_R)


### PR DESCRIPTION

## 🏷️ 티켓 번호
[PC-1282](https://yapp25app3.atlassian.net/browse/PC-1282)

## 👷🏼‍♂️ 변경 사항
- 라디오 버튼과 부모 뷰의 onTapGesture가 동시에 터치 이벤트를 처리하여 각 터치 이벤트가 충돌하는 문제가 존재하였음.
- PCRadio allowsHitTesting(false) 추가로 터치 이벤트 충돌 해결

 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |