### PR TITLE
[PC-1264] Fix: 프로필 관련 UI 변경

### DIFF
--- a/Presentation/Feature/MatchingDetail/Sources/MatchProfileBasic/MatchProfileBasicView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/MatchProfileBasic/MatchProfileBasicView.swift
@@ -127,7 +127,7 @@ struct MatchProfileBasicView: View {
         category: "나이",
         answer: { ageAnswer(basicInfoModel: basicInfoModel) }
       )
-      .frame(width: 144)
+      .frame(width: 140)
       
       ProfileCard(
         type: .matching,
@@ -149,7 +149,7 @@ struct MatchProfileBasicView: View {
         category: "활동 지역",
         answer: { regionAnswer(basicInfoModel: basicInfoModel) }
       )
-      .frame(width: 144)
+      .frame(width: 140)
       
       ProfileCard(
         type: .matching,

--- a/Presentation/Feature/PreviewProfile/Sources/MatchProfileBasic/PreviewProfileBasicView.swift
+++ b/Presentation/Feature/PreviewProfile/Sources/MatchProfileBasic/PreviewProfileBasicView.swift
@@ -98,7 +98,7 @@ struct PreviewProfileBasicView: View {
         category: "나이",
         answer: { ageAnswer(basicInfoModel: basicInfoModel) }
       )
-      .frame(width: 144)
+      .frame(width: 140)
       
       ProfileCard(
         type: .matching,
@@ -120,7 +120,7 @@ struct PreviewProfileBasicView: View {
         category: "활동 지역",
         answer: { regionAnswer(basicInfoModel: basicInfoModel) }
       )
-      .frame(width: 144)
+      .frame(width: 140)
       
       ProfileCard(
         type: .matching,

--- a/Presentation/Feature/Profile/Sources/ProfileView.swift
+++ b/Presentation/Feature/Profile/Sources/ProfileView.swift
@@ -115,7 +115,7 @@ struct ProfileView: View {
         category: "나이",
         answer: { ageAnswer(userProfile: userProfile) }
       )
-      .frame(width: 144)
+      .frame(width: 140)
       
       ProfileCard(
         type: .profile,
@@ -137,7 +137,7 @@ struct ProfileView: View {
         category: "활동 지역",
         answer: { locationAnswer(userProfile: userProfile) }
       )
-      .frame(width: 144)
+      .frame(width: 140)
       
       ProfileCard(
         type: .profile,


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1264](https://yapp25app3.atlassian.net/browse/PC-1264)

## 👷🏼‍♂️ 변경 사항
- 나이, 활동 지역 카드의 width 변경 (144->140)
- 해당 화면은 3가지입니다. (내 프로필, 가입 시 내 프로필 미리보기, 매칭 상대 프로필)
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-1264]: https://yapp25app3.atlassian.net/browse/PC-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ