### PR TITLE
[PC-1286] Feature: PCNetworkMonitor 모듈 구현

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -11,6 +11,7 @@ let project = Project.app(
     .externalDependency(dependency: .KakaoSDKUser),
     .externalDependency(dependency: .GoogleSignIn),
     .utility(target: .PCFirebase),
-    .utility(target: .PCAmplitude)
+    .utility(target: .PCAmplitude),
+    .utility(target: .PCNetworkMonitor)
   ]
 )

--- a/App/Sources/ContentView.swift
+++ b/App/Sources/ContentView.swift
@@ -4,11 +4,13 @@ import SwiftUI
 import DesignSystem
 import Entities
 import LocalStorage
+import PCNetworkMonitor
 
 struct ContentView: View {
   @State private var router = Router()
   @State private var coordinator = Coordinator()
   @State private var toastManager = PCToastManager()
+  @State private var networkMonitor = PCNetworkMonitor()
   
   var body: some View {
     NavigationStack(path: $router.path) {
@@ -23,6 +25,7 @@ struct ContentView: View {
     }
     .environment(router)
     .environment(toastManager)
+    .environment(networkMonitor)
     .onReceive(NotificationCenter.default.publisher(for: .deepLink)) { notification in
       guard
         let raw = notification.userInfo?["notificationType"] as? String,

--- a/App/Sources/PieceApp.swift
+++ b/App/Sources/PieceApp.swift
@@ -1,11 +1,11 @@
-import DesignSystem
+//import DesignSystem
 import PCFirebase
 import PCAmplitude
 import LocalStorage
-import Router
+//import Router
 import KakaoSDKCommon
 import KakaoSDKAuth
-import KakaoSDKUser
+//import KakaoSDKUser
 import GoogleSignIn
 import SwiftUI
 

--- a/Tuist/ProjectDescriptionHelpers/Modules.swift
+++ b/Tuist/ProjectDescriptionHelpers/Modules.swift
@@ -60,6 +60,7 @@ public extension Modules {
     case PCFoundationExtension
     case PCFirebase
     case PCAmplitude
+    case PCNetworkMonitor
     
     var path: String {
       "Utility/\(self.rawValue)"

--- a/Utility/PCNetworkMonitor/Project.swift
+++ b/Utility/PCNetworkMonitor/Project.swift
@@ -1,0 +1,13 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by 홍승완 on 10/5/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.dynamicFramework(
+  name: Modules.Utility.PCNetworkMonitor.rawValue,
+)

--- a/Utility/PCNetworkMonitor/Sources/PCNetworkMonitor.swift
+++ b/Utility/PCNetworkMonitor/Sources/PCNetworkMonitor.swift
@@ -1,0 +1,91 @@
+//
+//  PCNetworkMonitor.swift
+//  Piece-iOS
+//
+//  Created by 홍승완 on 10/5/25.
+//  Copyright © 2025 puzzly. All rights reserved.
+//
+
+import Network
+import Observation
+
+/// 네트워크 상태 변화를 감지하고 이벤트를 방출하는 모니터
+@MainActor
+@Observable
+public final class PCNetworkMonitor {
+  /// 현재 네트워크 이벤트 (연결, 끊어짐, 인터페이스 변경)
+  public private(set) var networkEvent: NetworkEvent? = nil
+  
+  /// 현재 네트워크 연결 상태
+  public private(set) var isConnected: Bool = true
+  
+  private let networkMonitor = NWPathMonitor()
+  private let networkQueue = DispatchQueue(label: "NetworkMonitor")
+
+  private var availableInterfaces: [String] = []
+  private var previousInterfaces: [String] = []
+  
+  /// 네트워크 이벤트 타입
+  public enum NetworkEvent: Equatable {
+    case connected
+    case disconnected
+    case interfaceChanged(from: [String], to: [String])
+  }
+  
+  /// 초기화 시 자동으로 네트워크 모니터링 시작
+  public init() {
+    startMonitoring()
+  }
+  
+  /// 네트워크 모니터링 시작
+  public func startMonitoring() {
+    networkMonitor.pathUpdateHandler = { [weak self] path in
+      Task { @MainActor in
+        await self?.handlePathUpdate(path)
+      }
+    }
+    networkMonitor.start(queue: networkQueue)
+  }
+  
+  /// 네트워크 모니터링 중지
+  public func stopMonitoring() {
+    networkMonitor.cancel()
+  }
+  
+  /// 현재 네트워크 상태 강제 확인
+  public func checkConnection() async {
+    await MainActor.run {
+      networkMonitor.pathUpdateHandler?(networkMonitor.currentPath)
+    }
+  }
+  
+  /// 네트워크 경로 변화 처리
+  /// - Parameter path: 새로운 네트워크 경로
+  private func handlePathUpdate(_ path: NWPath) async {
+    let wasConnected = isConnected
+    let wasInterfaces = availableInterfaces
+    
+    isConnected = path.status == .satisfied
+    availableInterfaces = path.availableInterfaces.map { $0.name }
+    previousInterfaces = wasInterfaces
+    
+    // 이벤트 감지 및 방출
+    let connectionChanged = wasConnected != isConnected
+    let interfaceChanged = Set(wasInterfaces) != Set(availableInterfaces)
+    
+    // 연결 상태 변화 처리
+    if connectionChanged {
+      networkEvent = isConnected ? .connected : .disconnected
+      print("DEBUG: 🌐 NetworkMonitor - 이벤트: \(networkEvent!)")
+    } else if interfaceChanged && isConnected {
+      // 연결된 상태에서만 인터페이스 변경 이벤트 발생
+      networkEvent = .interfaceChanged(from: wasInterfaces, to: availableInterfaces)
+      print("DEBUG: 🌐 NetworkMonitor - 이벤트: \(networkEvent!)")
+    }
+  }
+  
+  deinit {
+    networkMonitor.cancel()
+  }
+}
+


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-1286](https://yapp25app3.atlassian.net/browse/PC-1286)

## 👷🏼‍♂️ 변경 사항
### PCNetworkMonitor 모듈 구현
- **네트워크 상태 감지**: 연결/끊어짐/인터페이스 변경 감지
  - 연결: 
  ex) Wi-Fi 연결, 셀룰러 데이터 연결, 비행기모드 해제
  - 끊어짐: 
  ex) Wi-Fi 끊어짐, 셀룰러 데이터 끊어짐, 비행기모드 활성화
  - 인터페이스 변경:
   ex) Wi-Fi ↔ LTE 전환, Wi-Fi 네트워크 변경, 셀룰러 변경

- **이벤트 방출**: `connected`, `disconnected`, `interfaceChanged` 이벤트
  - 위 두 가지 외 내부 구현 캡슐화

  ```swift
    /// 네트워크 이벤트 타입
  public enum NetworkEvent: Equatable {
    case connected
    case disconnected
    case interfaceChanged(from: [String], to: [String])
  }
  ```
- **전역 상태 공유**: Environment를 통한 앱 전체 네트워크 상태 공유 기대

### Tuist 의존성 추가
- **Utility/PCNetworkMonitor** 모듈 추가
- 최상위 AppRoot에서 PCNetworkMonitor를 의존하여 네트워크 상태 변화를 감지하여 에러 감지 및 활용 예정
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 네트워크 변경 시 예시 |
| :--: |
| <img width="751" height="260" alt="image" src="https://github.com/user-attachments/assets/2c4cd8a5-1434-43e9-9c1a-51d88a35c3c1" /> |

[PC-1286]: https://yapp25app3.atlassian.net/browse/PC-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ